### PR TITLE
Madcadden steering patch for Street Drivin/Hard Drivin's Airborne.

### DIFF
--- a/src/mame/atari/harddriv.cpp
+++ b/src/mame/atari/harddriv.cpp
@@ -1331,7 +1331,7 @@ static INPUT_PORTS_START( strtdriv )
 	PORT_BIT( 0xff, 0x80, IPT_UNUSED )
 
 	PORT_START("mainpcb:12BADC.0")       /* 400000 - steering wheel */
-	PORT_BIT(0x3ff, 0x800, IPT_PADDLE) PORT_MINMAX(0x000, 0x3ff) PORT_SENSITIVITY(400) PORT_KEYDELTA(5) PORT_NAME("Steering Wheel")
+	PORT_BIT(0xfff, 0x280, IPT_PADDLE) PORT_MINMAX(0x000, 0x500) PORT_SENSITIVITY(100) PORT_KEYDELTA(5) PORT_NAME("Steering Wheel")
 
 	/* dummy ADC ports to end up with the same number as the full version */
 	PORT_START("mainpcb:12BADC.1")       /* FAKE */
@@ -1421,7 +1421,7 @@ static INPUT_PORTS_START( hdrivair )
 	PORT_BIT( 0xff, 0x80, IPT_UNUSED )
 
 	PORT_START("mainpcb:12BADC.0")       /* 400000 - steering wheel */
-	PORT_BIT(0x3ff, 0x800, IPT_PADDLE) PORT_MINMAX(0x000, 0x3ff) PORT_SENSITIVITY(400) PORT_KEYDELTA(5) PORT_REVERSE PORT_NAME("Steering Wheel")
+	PORT_BIT(0xfff, 0x280, IPT_PADDLE) PORT_MINMAX(0x000, 0x500) PORT_SENSITIVITY(100) PORT_KEYDELTA(5) PORT_REVERSE PORT_NAME("Steering Wheel")
 
 	/* dummy ADC ports to end up with the same number as the full version */
 	PORT_START("mainpcb:12BADC.1")


### PR DESCRIPTION
Fixed the input not just for wheels but controller now too. Analogue joystick steering is still a bit twitchy but it works and the car doesn't do donuts anymore. When turning fully to the left or right with the wheel the centre point doesn't go out of alignment anymore which used to cause the car to start pulling either to the left or right when the wheel was centred. Removed the dip switch toggle for wheel/joystick input selection as it is not needed now with the new code. 