### PR TITLE
Tidying up the hdrivair/strtdriv port descriptions/functions. - harddriv.cpp

### DIFF
--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -61,6 +61,54 @@ Known undumped pirates
   * Shizen Mahjong / Competition Mahjong (by Sachen, apparently dumped but hoarded)
   * Magic 7 Block - 百変七巧板
 
+Sega Game Toshokan games could be downloaded via the Mega Modem while a
+subscription was active. The existing dumps were either extracted from
+Sega's B-Club! game rental service or ripped from the Game no Kanzume
+compilations released on the Mega-CD.
+
+Known missing entries from the Sega Game Toshokan service
+
+  * Columns (1991)
+  * Flicky (1990)
+  * Kinetic Connection ① Nei Sword (1991)
+  * Kinetic Connection ② Ohana Batake (1991)
+  * Kinetic Connection ③ Shirogane wa Warau yo (1991)
+  * Kinetic Connection ④ Mogura no Oasobi (1991)
+  * Kinetic Connection ⑤ Lightning Nei (1991)
+  * Phantasy Star II - Nei's Adventure (2008) (Sega Ages 2500 Series Vol. 32)
+  * Pyramid Magic Editor (1991)
+  * Pyramid Magic Editor (1991)
+  * Pyramid Magic Soushuuhen (1992)
+  * Pyramid Magic Yokokuhen (1990)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 8-gatsu Vol. 2 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 8-gatsu Vol. 3 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 8-gatsu Vol. 4 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 8-gatsu Vol. 5 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 9-gatsu Vol. 1 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 9-gatsu Vol. 2 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 10-gatsu Vol. 1 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 10-gatsu Vol. 2 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 11-gatsu Vol. 1 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 11-gatsu Vol. 2 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 12-gatsu Vol. 1 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 12-gatsu Vol. 2 (1991)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 1-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 1-gatsu Vol. 2 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 2-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 2-gatsu Vol. 2 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 3-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 3-gatsu Vol. 2 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 4-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 4-gatsu Vol. 2 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 5-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 5-gatsu Vol. 2 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 6-gatsu Vol. 1 (1992)
+  * Riddle Wired - Quiz Dokusen Kigyou no Houkai 6-gatsu Vol. 2 (1992)
+  * Sega Music Collection Phantasy Star III (1991)
+  * Sega Music Collection Bonanza Brothers (1991)
+  * Sega Music Collection Sonic The Hedgehog (1991)
+  * Taiketsu! Columns (1991)
+
 TODO:
 - Phantasy Star (serial G-4534, pstarjmd) is actually a SMS cart in MD shell,
   which works in the MD thanks to VDP compatibility mode.
@@ -10128,8 +10176,8 @@ but dumps still have to be confirmed.
 	</software>
 
 	<software name="16tongnk" cloneof="16ton">
-		<description>16t (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>16t (Japan, ripped from Game no Kanzume Vol. 2)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -15589,7 +15637,7 @@ https://bootleggames.fandom.com/wiki/Chaoji_Dafuweng
 
 	<software name="dokidoki">
 		<description>Ikazuse! Koi no Doki Doki Penguin Land MD (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1992</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -15599,8 +15647,8 @@ https://bootleggames.fandom.com/wiki/Chaoji_Dafuweng
 	</software>
 
 	<software name="dokidokignk" cloneof="dokidoki">
-		<description>Ikazuse! Koi no Doki Doki Penguin Land MD (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Ikazuse! Koi no Doki Doki Penguin Land MD (Japan, ripped from Game no Kanzume Vol. 2)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -17042,7 +17090,7 @@ https://segaretro.org/Elitserien_96
 
 	<software name="labdeath" cloneof="fatallab">
 		<description>Shi no Meikyuu - Labyrinth of Death (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1990</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -17052,8 +17100,8 @@ https://segaretro.org/Elitserien_96
 	</software>
 
 	<software name="labdeathgnk" cloneof="fatallab">
-		<description>Shi no Meikyuu - Labyrinth of Death (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Shi no Meikyuu - Labyrinth of Death (Japan, ripped from Game no Kanzume Vol. 2)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="131072">
@@ -17678,12 +17726,12 @@ https://segaretro.org/Feng_Shen_Ying_Jie_Chuan
 	</software>
 
 	<software name="gamenko">
-		<description>Game no Kandume Otokuyou (Japan)</description>
+		<description>Game no Kanzume Otokuyou (Japan, Sega Channel)</description>
 		<year>1995</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="3145728">
-				<rom name="game no kandume otokuyou (jpn).bin" size="3145728" crc="cdad7e6b" sha1="31c66bd13abf4ae8271c09ec5286a0ee0289dbbc"/>
+				<rom name="game no kanzume otokuyou (jpn).bin" size="3145728" crc="cdad7e6b" sha1="31c66bd13abf4ae8271c09ec5286a0ee0289dbbc"/>
 			</dataarea>
 		</part>
 	</software>
@@ -18557,8 +18605,8 @@ Unemulated [Sega Mega Modem] features
 	</software>
 
 	<software name="hypermgnk" cloneof="hyperm">
-		<description>Hyper Marbles (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Hyper Marbles (Japan, ripped from Game no Kanzume Vol. 1)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -23781,8 +23829,8 @@ Black screen at intro
 	</software>
 
 	<software name="paddlegnk" cloneof="paddle">
-		<description>Paddle Fighter (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Paddle Fighter (Japan, ripped from Game no Kanzume Vol. 1)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -24114,7 +24162,7 @@ Black screen at intro
 
 	<software name="ps2aa">
 		<description>Phantasy Star II - Amia's Adventure (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1990</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -24147,7 +24195,7 @@ Black screen at intro
 
 	<software name="ps2ad">
 		<description>Phantasy Star II - Kinds's Adventure (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1990</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -24180,7 +24228,7 @@ Black screen at intro
 
 	<software name="ps2ag">
 		<description>Phantasy Star II - Shilka's Adventure (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1990</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -25065,7 +25113,7 @@ Black screen
 
 	<software name="putter">
 		<description>Putter Golf (Japan, Sega Game Toshokan)</description>
-		<year>1991</year>
+		<year>1990</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -25075,8 +25123,8 @@ Black screen
 	</software>
 
 	<software name="puttergnk" cloneof="putter">
-		<description>Putter Golf (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Putter Golf (Japan, ripped from Game no Kanzume Vol. 2)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -25181,8 +25229,8 @@ Black screen
 	</software>
 
 	<software name="pyramidgnk" cloneof="pyramid">
-		<description>Pyramid Magic (Japan, Game no Kandume MegaCD rip)</description>
-		<year>1991</year>
+		<description>Pyramid Magic (Japan, ripped from Game no Kanzume Vol. 1)</description>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
@@ -25787,10 +25835,11 @@ Red screen
 		</part>
 	</software>
 
-	<software name="riddle">
-		<description>Riddle Wired (Japan, Sega Game Toshokan)</description>
+	<software name="riddle81">
+		<description>Riddle Wired - Quiz Dokusen Kigyou no Houkai 8-gatsu Vol. 1 (Japan, Sega Game Toshokan)</description>
 		<year>1991</year>
 		<publisher>Sega</publisher>
+		<info name="alt_title" value="RIDDLE WIRED クイズ独占企業の崩壊 8月 VOL. 1"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
 				<rom name="riddle wired (jpn) (sn).bin" size="262144" crc="fae3d720" sha1="662ffc946978030125dc1274aeec5196bc9a721b"/>

--- a/hash/msx2_flop.xml
+++ b/hash/msx2_flop.xml
@@ -22,6 +22,18 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="mlg30">
+		<description>Mitsubishi ML-G30</description>
+		<year>1985</year>
+		<publisher>Mitsubishi</publisher>
+		<info name="usage" value="Requires a mouse. Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="mitsubishi ml-g30.dsk" size="737280" crc="95e46993" sha1="4a732bededded8ee863694ef186aa920a7f90b43"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="fs4600">
 		<description>National FS-4600</description>
 		<year>1986</year>
@@ -50,7 +62,7 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="fs5000">
-		<description>iNational FS-5000</description>
+		<description>National FS-5000</description>
 		<year>1986</year>
 		<publisher>National</publisher>
 		<part name="flop1" interface="floppy_3_5">
@@ -333,6 +345,39 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="easytlp2" supported="no">
+		<description>Easy Telopper II (Japan)</description>
+		<year>1987</year>
+		<publisher>Sony</publisher>
+		<notes>When running on a HB-F900, a 192KB ramdisk is supposed to be created on boot. Cartridge not fully dumped?</notes>
+		<info name="serial" value="HBS-H022D"/>
+		<info name="barcode" value="4901780069446"/>
+		<info name="usage" value="Requires a HB-F900 system. Requires a mouse."/>
+		<part name="cart" interface="msx_cart">
+			<!-- PCB contains: 3x MB834000 (512KB ROM), 1x OKI M27512ZB (64KB EPROM), a large 64pin OKI M71H003 ic, and 2x AKM6264ALP-12. -->
+			<feature name="slot" value="halnote"/>
+			<dataarea name="rom" size="0x100000">
+				<rom name="easy telopper ii - sony.rom" size="0x100000" crc="3f21be88" sha1="7bba3687cade37aa71b9bbf6d9ce5541d3d6d3d1" status="baddump"/>
+			</dataarea>
+			<!-- 2x AKM6264ALP-12 -->
+			<dataarea name="sram" size="16384"/>
+			<dataarea name="kanji" size="0x20000">
+				<rom name="lh5321l7.ic4" size="0x20000" status="nodump"/>
+			</dataarea>
+		</part>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Program Disk - プログラムディスク"/>
+			<dataarea name="flop" size="737280">
+				<rom name="easy telopper ii - sony (program disk).dsk" size="737280" crc="8bf0816c" sha1="8e731f3d8d83efb728d74341c67204547e8a4ce7"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Backup System Disk - パックアッッジムライスク"/>
+			<dataarea name="flop" size="737280">
+				<rom name="easy telopper ii - sony (backup system disk).dsk" size="737280" crc="1adbeaf7" sha1="9deb251abd670aca7334b7cf43c1269170c2d257"/>
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="halnote">
 		<description>HalNote (Japan)</description>
@@ -363,6 +408,61 @@ The following floppies came with the machines.
 			</dataarea>
 			<dataarea name="kanji" size="0x20000">
 				<rom name="lh5321l7.ic4" size="0x20000" status="nodump" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="nms1170" supported="no">
+		<description>NMS 1170 (Netherlands)</description>
+		<year>1986</year>
+		<publisher>Philips</publisher>
+		<notes>Included with NMS 1170 Barcode reader. NMS 1170 is not supported.</notes>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="nms 1170 - philips.dsk" size="368640" crc="76afa59b" sha1="3f61b31a8c2daa9969bd9a0468299a8c568f11df"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="nms1255" supported="no">
+		<description>MSX Data Communications (Netherlands, v1.7)</description>
+		<year>1987</year>
+		<publisher>Philips</publisher>
+		<notes>Included with NMS 1255 Modem package. NMS 1255 is not supported.</notes>
+		<info name="serial" value="NMS 8961/23"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="msx data communications - philips (v1.7).dsk" size="368640" crc="8ed5d1ea" sha1="4d5f4bc28171d0dde555a03a482d8164e81098ae" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="fsifa1" supported="no">
+		<description>Panasonic FS-IFA1 (Japan)</description>
+		<year>1988</year>
+		<publisher>Panasonic</publisher>
+		<notes>The interface cartridge, and supported printers are not emulated.</notes>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<!-- DFJN106ZA, contains a utility for the FW-PU1B handy printer. -->
+			<feature name="part_id" value="システムディスク1"/>
+			<dataarea name="flop" size="737280">
+				<rom name="fs-ifa1 - panasonic (disk 1).dsk" size="737280" crc="ddfc7f0f" sha1="7da9488cecd1c18a98b78e886f459138f044a48e"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<!-- DFJN111ZA, contains a utility for the FW-RSU1H/W image scanner. -->
+			<feature name="part_id" value="システムディスク2"/>
+			<dataarea name="flop" size="737280">
+				<rom name="fs-ifa1 - panasonic (disk 2).dsk" size="737280" crc="d47d9df0" sha1="a35700a81bb4f1a664583f8ecf23e564d7916ea7"/>
+			</dataarea>
+		</part>
+		<part name="cart" interface="msx_cart">
+			<feature name="part_id" value="Interface Cartridge"/>
+			<!-- unknown if it contains rom and/or ram. -->
+			<feature name="start_page" value="0"/>
+			<dataarea name="rom" size="0x4000">
+				<rom name="rom" size="0x4000" status="nodump" />
 			</dataarea>
 		</part>
 	</software>
@@ -963,6 +1063,34 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="amimoto" supported="no">
+		<description>Amimoto-san (Japan)</description>
+		<year>1988</year>
+		<publisher>MSX Magazine</publisher>
+		<notes>Modems are not supported yet.</notes>
+		<info name="alt_title" value="網元さん"/>
+		<info name="usage" value="Requires a Japanese system. Type HOST to start the BBS host software."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="amimoto-san - msx magazine.dsk" size="737280" crc="d890c857" sha1="9279bdd277d86d41c1fe3566374fd48cc3d1bf99"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="amimoto2" supported="no">
+		<description>Amimoto-san 2 (Japan)</description>
+		<year>1989</year>
+		<publisher>MSX Magazine</publisher>
+		<notes>Modems are not supported yet.</notes>
+		<info name="alt_title" value="網元さん2"/>
+		<info name="usage" value="Requires a Japanese system. Type HOST to start the BBS host software."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="amimoto-san 2 - msx magazine.dsk" size="368640" crc="13ef5870" sha1="7c0ecd30351c4eac15983b02693208f015941b23"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="angelus">
 		<description>Angelus (Japan)</description>
 		<year>1988</year>
@@ -1321,6 +1449,17 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="atlasenc">
+		<description>Atlas / Encyclopedie (Belgium)</description>
+		<year>1987</year> <!-- Not sure about this release date. -->
+		<publisher>DAInamic</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="atlas - encyclopedia - dainamic.dsk" size="368640" crc="24d595a8" sha1="e8c9b5bdad15e991d3279d2bb460b3b72bd06c72"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="dunbine">
 		<description>Aura Battler Dunbine (Japan)</description>
 		<year>1991</year>
@@ -1638,6 +1777,18 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="ebd89">
+		<description>Belasting Diskette 1989 (Netherlands)</description>
+		<year>1989</year>
+		<publisher>Elsevier</publisher>
+		<info name="usage" value="Type RUN&quot;EBD&quot;."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="belasting diskette 1989 - elsevier.dsk" size="368640" crc="7f45a2f3" sha1="12ed32b93dfdbfeff07ca67b5bde9f01a3196eac"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="birdywld">
 		<description>Birdy World (Japan)</description>
 		<year>1992</year>
@@ -1729,6 +1880,17 @@ The following floppies came with the machines.
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="block terminator (1988)(dot plan)(jp).dsk" size="737280" crc="6521fdb4" sha1="b234c31453e9e004c5d1753ea7e6048a96fae92c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="brnstorm">
+		<description>Brainstorm (Netherlands)</description>
+		<year>1993</year>
+		<publisher>MSX Club Gouda</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1049616">
+				<rom name="brainstorm - msx club gouda.dmk" size="1049616" crc="b56f4464" sha1="36199fc142979d221d45b6c90bdafcc1e7165014"/>
 			</dataarea>
 		</part>
 	</software>
@@ -2210,6 +2372,17 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="cheatmaster">
+		<description>Cheat Master (Netherlands)</description>
+		<year>1992</year>
+		<publisher>MSX Engiine</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="cheat master - msx engine.dsk" size="737280" crc="28e3568e" sha1="7cdafe650a00d25fda9b8258530fdfbb1a27c03a"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Generation-msx lists this as a single sided release. -->
 	<!-- Software visibly boots through MSX-DOS. -->
 	<software name="chessgm2">
@@ -2413,6 +2586,18 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="compassf">
+		<description>Compass - Finally Free Edition (v1.2.09)</description>
+		<year>2021</year>
+		<publisher>Compjoetania</publisher>
+		<info name="usage" value="Type COMPASS to start the software."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="compass - finally free edition - compjoetania.dsk" size="737280" crc="a87f502a" sha1="0dacbbc6800e4e8478c0ff4b0132a8929612efab"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="consmaze">
 		<description>Construction Tool Meizu-kun (Japan)</description>
 		<year>1989</year>
@@ -2455,6 +2640,73 @@ The following floppies came with the machines.
 			<feature name="part_id" value="Disk D"/>
 			<dataarea name="flop" size="737280">
 				<rom name="continental - technopolis soft (disk d).dsk" size="737280" crc="2243f1dc" sha1="1c2c142de73fe57da240671cd7d824833f210414"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="copyaid">
+		<description>Copy Aid Tenka Muteki (Japan, v2.32+)</description>
+		<year>1993</year>
+		<publisher>SOFTPAL</publisher>
+		<info name="alt_title" value="COPY AID 天下無敵"/>
+		<info name="release" value="19930220"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="copy aid tenka muteki - softpal (v2.32p).dsk" size="737280" crc="635e7b38" sha1="97b5ee865b16071c8ce58137b49913eb6378db4c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="copyaid232" cloneof="copyaid">
+		<description>Copy Aid Tenka Muteki (Japan, v2.32)</description>
+		<year>1993</year>
+		<publisher>SOFTPAL</publisher>
+		<info name="alt_title" value="COPY AID 天下無敵"/>
+		<info name="release" value="199302??"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="copy aid tenka muteki - softpal (v2.32).dsk" size="737280" crc="1501a6d8" sha1="75ccb3179e4868a17cbe326a541443190d5592c4"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="copyaid230" cloneof="copyaid">
+		<description>Copy Aid Tenka Muteki (Japan, v2.30)</description>
+		<year>1991</year>
+		<publisher>SOFTPAL</publisher>
+		<info name="alt_title" value="COPY AID 天下無敵"/>
+		<info name="release" value="19910622"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="copy aid tenka muteki - softpal (v2.30).dsk" size="737280" crc="4523a583" sha1="b790c38aa05e5940eb78ccbba35107821b4cfcca"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="copyaid220" cloneof="copyaid">
+		<description>Copy Aid Tenka Muteki (Japan, v2.20)</description>
+		<year>1989</year>
+		<publisher>SOFTPAL</publisher>
+		<info name="alt_title" value="COPY AID 天下無敵"/>
+		<info name="release" value="19890409"/>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="copy aid tenka muteki - softpal (v2.20).dsk" size="737280" crc="64dc588d" sha1="ff43c148ee2f02fbfbcf05652414944561f8d217"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="copyaid212" cloneof="copyaid">
+		<description>Copy Aid Tenka Muteki (Japan, v2.12)</description>
+		<year>1989</year>
+		<publisher>SOFTPAL</publisher>
+		<info name="alt_title" value="COPY AID 天下無敵"/>
+		<info name="release" value="19891118"/>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="copy aid tenka muteki - softpal (v2.12).dsk" size="737280" crc="6744a170" sha1="69281a4026c00027ea5eef62a6416252e8153451"/>
 			</dataarea>
 		</part>
 	</software>
@@ -3214,6 +3466,18 @@ The following floppies came with the machines.
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="deep forest (1987)(xain)(jp)[a3].dsk" size="737280" crc="5a8a693b" sha1="4cd8323d915875a63f7e44be55ab96073380900d"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="demokitdx">
+		<description>DemoKit Deluxe (Netherlands)</description>
+		<year>1990</year>
+		<publisher>NewVision</publisher>
+		<info name="usage" value="Requires a mouse."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1032442">
+				<rom name="demokit deluxe - newvision.dmk" size="1032442" crc="481d4290" sha1="0ebee22ba0674f73f1351db63757f527375cd5e3"/>
 			</dataarea>
 		</part>
 	</software>
@@ -4648,6 +4912,19 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="diskal42">
+		<description>Disk Album 42 - MSX-C Nyuumon Jougekan (Japan)</description>
+		<year>1991</year>
+		<publisher>ASCII</publisher>
+		<info name="alt_title" value="Disk Album 42 MSX-C入門　上下巻"/>
+		<info name="usage" value="Requires MSX-DOS."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="disk album 42 - ascii.dsk" size="737280" crc="0a8d2275" sha1="854115d05adcda8811ed4130c00ee9b590e523a4"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="manilove">
 		<description>Disk Mystery #4 - The Man I Love (Japan)</description>
 		<year>1988</year>
@@ -5601,6 +5878,17 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="dupedisk">
+		<description>DupeDisk (Netherlands, v1.02)</description>
+		<year>1992</year>
+		<publisher>U.M.F.</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="dupedisk - u.m.f. (v1.02).dsk" size="737280" crc="77200358" sha1="d09156eb64a6834a1e19b27240ba33347d1222a1"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="dynampbl">
 		<description>Dynamic Publisher (Spain)</description>
 		<year>1988</year>
@@ -6183,6 +6471,70 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="f1td">
+		<description>F1 Tool Disk (Japan)</description>
+		<year>1988</year>
+		<publisher>Sony</publisher>
+		<notes>This software came with Sony HB-F1XD, HBD-F1, and HBD-20W machines in early 1988.</notes>
+		<info name="alt_title" value="Ｆ１ツールディスク"/>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="f1 tool disk - sony.dsk" size="737280" crc="8a70c1eb" sha1="eaa5a4461643379aadd28b4fe8e673de8e4c8e51"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="f1td2">
+		<description>F1 Tool Disk II (Japan)</description>
+		<year>1989</year>
+		<publisher>Sony</publisher>
+		<notes>This software came with Sony HB-F1XDJ computer or HBP-F1C printer in early 1989.</notes>
+		<info name="alt_title" value="F1ツールディスクII"/>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="f1 tool disk ii - sony.dsk" size="737280" crc="cbbbb332" sha1="b0a317fc46a3f0f4b14e04dc4e85900d1e1b0144"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="facst2">
+		<description>FAC Soundtracker (Netherlands, v2.0)</description>
+		<year>1991</year>
+		<publisher>MSX-Club West-Friesland</publisher>
+		<!-- The MSX-Club West-Friesland release contains just FAC Soundtracker 2.0. The MK Public Domain release includes FAC Music Disk #3. -->
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1033616">
+				<rom name="fac soundtracker - msx-club west-friesland (v2.0).dmk" size="1033616" crc="89a71f11" sha1="37ca4b29fbe809cf79c9f70cf9d3d3f2394eaec7"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="facstp103">
+		<description>FAC Soundtracker Pro (Netherlands, v1.03)</description>
+		<year>1994</year>
+		<publisher>MSX-Club West-Friesland</publisher>
+		<!-- According to generation-msx the release contained 4 floppies. -->
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1019056">
+				<rom name="fac soundtracker pro - msx-club west-friesland (v1.03).dmk" size="1019056" crc="530cf16c" sha1="ef594a8eb6fba5262da393549a67da43c4127131"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="facstp92" cloneof="facstp103">
+		<description>FAC Soundtracker Pro (Netherlands, 1992)</description>
+		<year>1992</year>
+		<publisher>MK Public Domain</publisher>
+		<!-- According to generation-msx the release contained 4 floppies. -->
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="fac soundtracker pro - mk public domain.dsk" size="737280" crc="92e457d9" sha1="56ccc6cb4310a2670bc87a3fe49b108c69a89239"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="fahrn451">
 		<description>Fahrenheit 451 (Spain, cracked)</description>
 		<year>1986</year>
@@ -6554,6 +6906,19 @@ The following floppies came with the machines.
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
 				<rom name="fistan - stark-texel (v2.05).dsk" size="368640" crc="09e56e37" sha1="7f97254df972090e51f68cfe4b74ce8f575c0ea9"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="focus">
+		<description>MSX2 Disk Backup Tool - Focus (Japan, v2.0)</description>
+		<year>1988</year>
+		<publisher>I.C.C.</publisher>
+		<info name="alt_title" value="MSX2ディスクバックアップツール・フォーカス"/>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="msx2 disk backup tool - focus - i.c.c..dsk" size="737280" crc="5f7e5dcd" sha1="0a1c882316c09618ee8f56e92934a4d741fc6a4f"/>
 			</dataarea>
 		</part>
 	</software>
@@ -7067,6 +7432,43 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="gfx9ktb" supported="no">
+		<description>GFX9000 Toolbox</description>
+		<year>2003</year>
+		<publisher>Sunrise for MSX</publisher>
+		<notes>GFX9000 is not emulated.</notes>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="G-BASIC - PowerBASIC"/>
+			<dataarea name="flop" size="737280">
+				<rom name="gfx9000 toolbox - sunrise for msx (gbasic).dsk" size="737280" crc="efb52d03" sha1="1d30f29099229e5088f58fcb1ff6f9bf01c8b2e3"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Paint9000 - GFXAGE"/>
+			<dataarea name="flop" size="737280">
+				<rom name="gfx9000 toolbox - sunrise for msx (paint9000).dsk" size="737280" crc="97669e0a" sha1="ca47d5895103762e37986c6edb521bb2cb8c1a29"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="PicView"/>
+			<dataarea name="flop" size="737280">
+				<rom name="gfx9000 toolbox - sunrise for msx (picview).dsk" size="737280" crc="a2b184ca" sha1="7c075bdc84feaf06e2868495a160a4a5ba6fde53"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="FLI Player"/>
+			<dataarea name="flop" size="737280">
+				<rom name="gfx9000 toolbox - sunrise for msx (fli player).dsk" size="737280" crc="b4f02616" sha1="3ca1bd9e4590cdc00689e3d77f0cac803f6cd513"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="DEMOS - PowerBASIC"/>
+			<dataarea name="flop" size="737280">
+				<rom name="gfx9000 toolbox - sunrise for msx (demos).dsk" size="737280" crc="d4179b09" sha1="e321a20f92398c9eed2fb0d8186185dc21536a40"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="giddyrun">
 		<description>Giddy Runner (Japan)</description>
 		<year>1990</year>
@@ -7464,10 +7866,10 @@ The following floppies came with the machines.
 
 	<!-- The software release contained 2 floppies. -->
 	<software name="graphsar10" cloneof="graphsar">
-		<description>Graph Saurus v1.0 (Japan)</description>
+		<description>Graph Saurus Ver1.0 (Japan)</description>
 		<year>1989</year>
 		<publisher>Bit²</publisher>
-		<info name="alt_title" value="グラフサウルス"/>
+		<info name="alt_title" value="グラフ サウルス"/>
 		<info name="serial" value="BM-021"/>
 		<info name="gtin" value="04988655132108"/>
 		<part name="flop1" interface="floppy_3_5">
@@ -7478,10 +7880,10 @@ The following floppies came with the machines.
 	</software>
 
 	<software name="graphsar">
-		<description>Graph Saurus v2.0 (Japan)</description>
+		<description>Graph Saurus Ver2.0 (Japan)</description>
 		<year>1991</year>
 		<publisher>Bit²</publisher>
-		<info name="alt_title" value="グラフサウルスＶｅｒ．２．０"/>
+		<info name="alt_title" value="グラフ サウルス version 2.0"/>
 		<info name="serial" value="BM-124"/>
 		<info name="gtin" value="04988655632219"/>
 		<info name="usage" value="Requires a Japanese system."/>
@@ -7563,6 +7965,23 @@ The following floppies came with the machines.
 			<feature name="part_id" value="Utility disk"/>
 			<dataarea name="flop" size="737280">
 				<rom name="graph saurus v2.0 (1991)(bit2)(jp)(disk 2 of 2).dsk" size="737280" crc="1b2a1703" sha1="42b5aa813627d464dafbcadddf394b0e6ab1e9dd"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="graphs21" supported="no">
+		<description>Graph Saurus Ver.2.1 Interlace Mode Plus (Japan)</description>
+		<year>1993</year>
+		<publisher>Bit²</publisher>
+		<info name="alt_title" value="グラフサウルスVer.2.1インターレスモードプラス"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="graph saurus v2.1 - bit2 (disk 1).dsk" size="737280" crc="cb3270ed" sha1="1f02daabbd053fdfa82b6e2b2c8b80255056c087"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="graph saurus v2.1 - bit2 (disk 2).dsk" size="737280" status="nodump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -8120,6 +8539,28 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="homeoffi">
+		<description>Home Office - MSX Designer (Italy)</description>
+		<year>1986</year>
+		<publisher>Philips</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="home office - msx designer - philips (italy).dsk" size="368640" crc="7c0d69b6" sha1="3956fd13d30ba0d7224756fab8d60383c973b67a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="homeof2i">
+		<description>Home Office 2 (Italy)</description>
+		<year>1986</year>
+		<publisher>Philips</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="home office 2 - philips (italy).dsk" size="368640" crc="8b6bda4a" sha1="97e0bb1c6d8c993116e93ac70d008e27b54bf39a"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="hotmilk">
 		<description>Hot Milk (Japan)</description>
 		<year>1989</year>
@@ -8320,6 +8761,17 @@ The following floppies came with the machines.
 			<feature name="part_id" value="Disk C"/>
 			<dataarea name="flop" size="737280">
 				<rom name="illumina - cocktail soft (disk c).dsk" size="737280" crc="d150621f" sha1="1bbb590b2b83daea0f937c40087970e2566f4b7c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="imgmaker">
+		<description>Image Maker &amp; Poster 8 (Netherlands)</description>
+		<year>1990</year>
+		<publisher>MSX Gids</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="image maker &amp; poster 8 - msx gids.dsk" size="368640" crc="1c9c5e2b" sha1="802f111a614a00a72f9b7dd20258a52357ac77c6"/>
 			</dataarea>
 		</part>
 	</software>
@@ -10196,6 +10648,18 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="melbnote">
+		<!-- Software is in English -->
+		<description>Melbrains Note (Japan?)</description>
+		<year>1986</year>
+		<publisher>Mel Software</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="melbrains note - mel software.dsk" size="737280" crc="fd54d0d0" sha1="c528a7254478c4bca48787111f3f8441d24d1050"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="membgolf">
 		<description>Membership Golf (Japan)</description>
 		<year>1989</year>
@@ -10376,6 +10840,31 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="midisaurus">
+		<description>MIDI Saurus (Japan)</description>
+		<year>1990</year>
+		<publisher>Bit²</publisher>
+		<notes>Before starting the software the system will be rebooted automatically.</notes>
+		<info name="alt_title" value="MIDI サウルス"/>
+		<info name="barcode" value="4988655211100"/>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1018896">
+				<rom name="midi saurus - bit2 (disk 1).dmk" size="1018896" crc="41cee38f" sha1="1b73e61446c2fc6e27cdcd118774de5b1b977e4c"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<!-- Identical disks? The disks seem to have the same labels. -->
+			<dataarea name="flop" size="1018896">
+				<rom name="midi saurus - bit2 (disk 2).dmk" size="1018896" crc="41cee38f" sha1="1b73e61446c2fc6e27cdcd118774de5b1b977e4c"/>
+			</dataarea>
+		</part>
+		<part name="cart" interface="msx_cart">
+			<feature name="slot" value="bm_012"/>
+			<dataarea name="dummy" size="1"/>
+		</part>
+	</software>
+
 	<software name="mightmg2">
 		<description>Might and Magic II - Gates to Another World (Japan)</description>
 		<year>1989</year>
@@ -10549,6 +11038,56 @@ The following floppies came with the machines.
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="mobile suit field gundam (1988)(family soft)(jp).dsk" size="737280" crc="0609e85d" sha1="89392c0acf277f271d9f53231685004c9565ba47"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="moonblst14">
+		<description>MoonBlaster (Netherlands, v1.4)</description>
+		<year>1992</year>
+		<publisher>Stichting Sunrise</publisher>
+		<info name="serial" value="SR002"/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Program"/>
+			<dataarea name="flop" size="368640">
+				<rom name="moonblaster - stichting sunrise (program).dsk" size="368640" crc="65b627c1" sha1="78698f5a7558f7f3af5e709e43f03138fd7640ad"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Samples"/>
+			<dataarea name="flop" size="368640">
+				<rom name="moonblaster - stichting sunrise (samples).dsk" size="368640" crc="7064307f" sha1="621138309b2b18f6ce3d662fdb7af04f648685b9"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Music"/>
+			<dataarea name="flop" size="368640">
+				<rom name="moonblaster - stichting sunrise (music).dsk" size="368640" crc="2d2613d6" sha1="6bf94800426abee4260fcfaa3a542dea964c4abf"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="moonbms2">
+		<description>MoonBlaster Music #2 (Netherlands)</description>
+		<year>1993</year>
+		<publisher>Stichting Sunrise</publisher>
+		<info name="serial" value="SR006"/>
+		<info name="usage" value="Requires the screen to be 80 characters wide before starting the software."/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Music #2"/>
+			<dataarea name="flop" size="737280">
+				<rom name="moonblaster music 2 - stichting sunrise.dsk" size="737280" crc="02644601" sha1="44ba8ac04dbeda320a978f54e87b95bea56e99ac"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="msxbaskn">
+		<description>MSX BASIC Kun (Netherlands)</description>
+		<year>1988</year>
+		<publisher>Sparrowsoft</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="msx basic kun - sparrowsoft.dsk" size="368640" crc="3d4a0a3c" sha1="8559d7d61c91711bd817ba57142fac5a6ef89256"/>
 			</dataarea>
 		</part>
 	</software>
@@ -10784,6 +11323,19 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="msxtechg">
+		<description>MSX Technical Guidebook - The Fourth Edition (Japan)</description>
+		<year>1991</year>
+		<publisher>ASCAT</publisher>
+		<info name="alt_title" value="MSXテクニカルガイドフック第四版"/>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="msx technical guide daiyonhan - ascat.dsk" size="368640" crc="a35e6625" sha1="2f15e47e423c428c761d132fceb80d66b6f8c178"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="msxtrain">
 		<description>MSX Train (Japan)</description>
 		<year>1993</year>
@@ -10835,6 +11387,42 @@ The following floppies came with the machines.
 		<part name="flop4" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="msx train 2 - family soft (disk 4).dsk" size="737280" crc="5b4f4605" sha1="1ef3f533a95c0a0975081ac11896b2e91189ffbb"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="multbarc" supported="no">
+		<description>Multi-Barcode (Netherlands)</description>
+		<year>1991</year>
+		<publisher>Club van Zes</publisher>
+		<notes>Barcode reader/pen is not supported.</notes>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="multi-barcode - club van zes.dsk" size="368640" crc="8626c7bb" sha1="5f7771492522c8772a5006d0afcddd8bb4658361"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="barad" cloneof="multbarc" supported="no">
+		<description>Barad (Netherlands)</description>
+		<year>1991</year>
+		<publisher>Club van Zes</publisher>
+		<notes>Barcode reader/pen is not supported.</notes>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="barad - club van zes.dsk" size="368640" crc="c4f5a1d0" sha1="8dcf572668da10cc6f478794a7fadaadf2388db0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="onchikun">
+		<description>Music Editor Onchi-kun (Japan)</description>
+		<year>1988</year>
+		<publisher>Winky Soft</publisher>
+		<info name="alt_title" value="ミュージックエディター音知くん"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="music editor onchi kun - winky soft.dsk" size="737280" crc="80c7dff7" sha1="69a59e0b5218e515507aeeb76b48e109f6a62edd"/>
 			</dataarea>
 		</part>
 	</software>
@@ -10924,6 +11512,28 @@ The following floppies came with the machines.
 			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="737280">
 				<rom name="nichiyoubi uchuujin. alien sunday (1986)(software studio wing)(jp)(disk 2 of 2).dsk" size="737280" crc="e8f006ab" sha1="c661269c58525f46cdc4b3a83a5e363caeb29e80"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="niwabusa">
+		<description>Nihongo Waupuro Bunsho Sakuzaemon (Japan)</description>
+		<year>1988</year>
+		<publisher>Sony</publisher>
+		<info name="alt_title" value="日本語ワープロ・文書作左衛門"/>
+		<info name="serial" value="HBS-B012D"/>
+		<info name="barcode" value="4901780087181"/>
+		<info name="usage" value="Requires MSX-JE."/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Program disk - プログラムディスク"/>
+			<dataarea name="flop" size="737280">
+				<rom name="nihongo waupuro bunsho sakuzaemon - sony (program disk).dsk" size="737280" crc="c640b85f" sha1="c49b36cb844598e32226815977fbbb6d4b1a1de9"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Illustration disk - イラストディスク"/>
+			<dataarea name="flop" size="737280">
+				<rom name="nihongo waupuro bunsho sakuzaemon - sony (illustration disk).dsk" size="737280" crc="eb276dfa" sha1="ad69a084457073c472cc7b87c8da121c7695ee01"/>
 			</dataarea>
 		</part>
 	</software>
@@ -11417,6 +12027,18 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="palet2">
+		<description>Palet 2 (Netherlands)</description>
+		<year>1987</year>
+		<publisher>Sparrowsoft</publisher>
+		<info name="usage" value="Requires a mouse."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="palet 2 - sparrowsoft.dsk" size="368640" crc="bfaadffc" sha1="e16485315f0f881df4cae95715fb0076c4a3e1bd"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="pacdisc" supported="no">
 		<description>Pana Amusement Collection Disc (Japan)</description>
 		<year>1988</year>
@@ -11818,6 +12440,18 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="phdigdsk" supported="no">
+		<description>Philips NMS 8280 Digitiser Disk (Netherlands)</description>
+		<year>1995</year>
+		<publisher>MSX-Club West-Friesland</publisher>
+		<notes>Digitising is not supported.</notes>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="philips nms 8280 digitiser disk - msx-club west-friesland.dsk" size="737280" crc="b33e1b3e" sha1="9c644ec87dad61896e5945238efafe0e8a20d92b"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="pias">
 		<description>PIAS - Hikisakareta Seishun (Japan)</description>
 		<year>1991</year>
@@ -11833,6 +12467,18 @@ The following floppies came with the machines.
 			<feature name="part_id" value="Disk B"/>
 			<dataarea name="flop" size="737280">
 				<rom name="pias - hikisakareta seishun - birdy software (disk b).dsk" size="737280" crc="627db361" sha1="997b63c03e3765217c2d6de2c512e36d9e32e883"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pictkitd">
+		<description>PictureKit Deluxe (Netherlands)</description>
+		<year>1990</year>
+		<publisher>NewVision</publisher>
+		<info name="usage" value="Requires a mouse."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1019536">
+				<rom name="picturekit deluxe - newvision.dmk" size="1019536" crc="dac04ed9" sha1="cfd688222e95aff24c67eedc9d2af352a9727785"/>
 			</dataarea>
 		</part>
 	</software>
@@ -12456,7 +13102,7 @@ The following floppies came with the machines.
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_3_5">
-			<feature name="part_id" value="Disk NO.7"/>
+			<feature name="part_id" value="Disk NO.6"/>
 			<dataarea name="flop" size="737280">
 				<rom name="princess maker v2 (1992)(micro cabin)(jp)(disk 6 of 7).dsk" size="737280" crc="42001e1f" sha1="f9847d3ee2d8eb7786901dec6e2d0bf5de2e0c8b"/>
 			</dataarea>
@@ -12490,6 +13136,51 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="printshop2" supported="no">
+		<description>Print Shop II (Japan)</description>
+		<year>1989</year>
+		<publisher>Sony</publisher>
+		<notes>Seems to be protected. Title screen loads over and over.</notes>
+		<info name="alt_title" value="プリントショップII"/>
+		<info name="serial" value="HBS-B014D"/>
+		<info name="barcode" value="4901780100828"/>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System Disk - システムディスク"/>
+			<dataarea name="flop" size="737280">
+				<rom name="print shop ii - sony (system disk).dsk" size="737280" crc="473ecd82" sha1="848cd3655bcd897a7facb4d99ad3b1ac9ccca6b1"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Shotai Disk - 書体ディスク"/>
+			<dataarea name="flop" size="737280">
+				<rom name="print shop ii - sony (typeface disk).dsk" size="737280" crc="a90c5336" sha1="26e8e403efd9f0bc3394a76f2c45bbe9480c1b6e"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="printshop2c" cloneof="printshop2">
+		<description>Print Shop II (Japan, cracked)</description>
+		<year>1989</year>
+		<publisher>Sony</publisher>
+		<info name="alt_title" value="プリントショップII"/>
+		<info name="serial" value="HBS-B014D"/>
+		<info name="barcode" value="4901780100828"/>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System Disk - システムディスク"/>
+			<dataarea name="flop" size="737280">
+				<rom name="print shop ii - sony (system disk, cracked).dsk" size="737280" crc="19a322cc" sha1="936c683d1f9a6e344189615779196fd632e9e5ab"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Shotai Disk - 書体ディスク"/>
+			<dataarea name="flop" size="737280">
+				<rom name="print shop ii - sony (typeface disk).dsk" size="737280" crc="a90c5336" sha1="26e8e403efd9f0bc3394a76f2c45bbe9480c1b6e"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="proyakfn">
 		<description>Pro Yakyu Fan (Japan)</description>
 		<year>1988</year>
@@ -12498,6 +13189,17 @@ The following floppies came with the machines.
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="pro baseball fan (1988)(telenet japan)(jp).dsk" size="737280" crc="27ddb9a3" sha1="f096a3bc95cfcd45c4bfec6abdd17d718ff84be4"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="psgtracker">
+		<description>PSG Tracker (Netherlands)</description>
+		<year>1992</year>
+		<publisher>Flying Bytes</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="psg tracker - flying bytes.dsk" size="368640" crc="fc1843a0" sha1="20245ad973bccd2f5a2098f1d163c19bfae8292d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -15138,6 +15840,18 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="supersd">
+		<description>Superscreendumper (Netherlands)</description>
+		<year>1988</year>
+		<publisher>Sparrowsoft</publisher>
+		<info name="usage" value="Type RUN&quot;SDUMP.BAS&quot; to start the software."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="superscreendumper - sparrowsoft.dsk" size="368640" crc="0c434e44" sha1="66f1f182fa0b20f8b5621eceeb218147ca8e9414"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="suzumebg">
 		<description>Jong Borg Suzume (Japan)</description>
 		<year>1990</year>
@@ -15172,11 +15886,27 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<software name="synthsa2">
-		<description>Synth Saurus v2.0 (Japan)</description>
+	<!-- v2.03 is only referenced once. The other verion references are still 2.00. -->
+	<software name="synthsa203">
+		<description>Synth Saurus Ver2.0 (Japan, v2.03)</description>
 		<year>1989</year>
 		<publisher>Bit²</publisher>
-		<info name="alt_title" value="シンセサウルスＶｅｒ．２．０"/>
+		<info name="alt_title" value="シンセサウルス version 2.0"/>
+		<info name="serial" value="BM-912"/>
+		<info name="gtin" value="04988655231191"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="synth saurus v2.0 - bit2 (v2.03).dsk" size="737280" crc="2f056983" sha1="fcbff56b458c48e8df5573c749ce1c5684581a50"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- The data only has references to 2.00, assuming this is v2.00. -->
+	<software name="synthsa2" cloneof="synthsa203">
+		<description>Synth Saurus Ver2.0 (Japan)</description>
+		<year>1989</year>
+		<publisher>Bit²</publisher>
+		<info name="alt_title" value="シンセサウルス version 2.0"/>
 		<info name="serial" value="BM-912"/>
 		<info name="gtin" value="04988655231191"/>
 		<part name="flop1" interface="floppy_3_5">
@@ -15194,6 +15924,38 @@ The following floppies came with the machines.
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="t.d.f. (1988)(data west)(jp).dsk" size="737280" crc="dce72c5f" sha1="d4349a19fc63c2a5ef7fb39238b02a104b5442a7"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tmaker4">
+		<description>T/Maker IV</description>
+		<year>1985</year>
+		<publisher>Sony</publisher>
+		<info name="serial" value="HBS-B007D"/>
+		<info name="usage" value="Type TMAKER to start the software."/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk A"/>
+			<dataarea name="flop" size="1046008">
+				<rom name="t-maker - sony (disk a).dmk" size="1046008" crc="ff1df085" sha1="18de9820ea649f9145d0e46b07a136e82772a37a"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk B"/>
+			<dataarea name="flop" size="1046008">
+				<rom name="t-maker - sony (disk b).dmk" size="1046008" crc="2119caa3" sha1="4a86ceca16c81b16f377b85f7bd6f5f446e0ca79"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tvkrant">
+		<description>De T.V. Krant (Netherlands)</description>
+		<year>1987</year>
+		<publisher>Oasis</publisher>
+		<info name="usage" value="Requires disk to not be write protected."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="de t.v. krant - oasis.dsk" size="737280" crc="3aeecd87" sha1="38d3974a4dd6de5dc4aab5587125542e18a0c92e"/>
 			</dataarea>
 		</part>
 	</software>
@@ -15876,6 +16638,17 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="trbltwn">
+		<description>Troubles in Town (Netherlands)</description>
+		<year>1991</year>
+		<publisher>MK Public Domain</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1030822">
+				<rom name="troubles in town - mk public domain.dmk" size="1030822" crc="7847d03e" sha1="ba944bc1f775335c09d47ab228a5c386c5666b47"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="toshinto">
 		<description>Toushin Toshi (Japan)</description>
 		<year>1990</year>
@@ -16101,6 +16874,17 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
+	<software name="turbowipe">
+		<description>Turbowipe (Netherlands)</description>
+		<year>1991</year>
+		<publisher>NewVision</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="turbowipe - newvision.dsk" size="737280" crc="afbbc30f" sha1="3ada8ae299c762dc44c808a05be0b07283346746"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="twinkle">
 		<description>Twinkle Star - Hoshi no Mahou Tsukai (Japan)</description>
 		<year>1990</year>
@@ -16181,6 +16965,18 @@ The following floppies came with the machines.
 			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="737280">
 				<rom name="ultima iv - quest of the avatar (1987)(pony canyon)(jp)(disk 2 of 2).dsk" size="737280" crc="6e7a1784" sha1="1ce762b191bb3cf31272fc8ecbf48df38cb5f9cc"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ultrabasic">
+		<description>Ultra BASIC (Netherlands)</description>
+		<year>1988</year>
+		<publisher>MSX Gids</publisher>
+		<info name="usage" value="RUN&quot;ULTRA.BAS&quot;. To run the demo: RUN&quot;ULT-DEMO.BAS&quot;."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="ultra basic - msx gids.dsk" size="368640" crc="1be7b833" sha1="b5d8b32f8c1e804598aef189712b07140e1fd84b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -16802,6 +17598,17 @@ The following floppies came with the machines.
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="wonderful adventures of a little princess (1987)(champion soft)(jp).dsk" size="737280" crc="5e6e50e7" sha1="24ac626ef06d85be0bb502b2280c2335d377df43"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="workmate">
+		<description>Workmate (Europe)</description>
+		<year>1989</year>
+		<publisher>Checkmark</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1018096">
+				<rom name="workmate - checkmark.dmk" size="1018096" crc="6f0af281" sha1="b539042dc3655f6e0e15118a8b7233dbf7d1ceb1"/>
 			</dataarea>
 		</part>
 	</software>
@@ -18005,14 +18812,13 @@ The following floppies came with the machines.
 		</part>
 	</software>
 
-	<!-- According to generation-msx this was released on single sided floppy. -->
 	<software name="zoo">
 		<description>Zoo (Europe)</description>
 		<year>1989</year>
 		<publisher>Radarsoft</publisher>
 		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="737280">
-				<rom name="zoo - radarsoft.dsk" size="737280" crc="370ba756" sha1="d963fbf94b1a3f478f924bbb0223f21f597cecd3" status="baddump"/>
+			<dataarea name="flop" size="1022896">
+				<rom name="zoo - radarsoft.dmk" size="1022896" crc="12254093" sha1="35337065f47a46e505ea2bf12411a6af469a7e15"/>
 			</dataarea>
 		</part>
 	</software>
@@ -18237,6 +19043,19 @@ HOMEBREW
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
 				<rom name="alien slime (1990)(ax-alex - raketto)[a2].dsk" size="368640" crc="404a3a0f" sha1="48eaaeff9ed3c7fe06db760797ec1831cc6662e3"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="animecha2">
+		<description>Animecha (Japan, v2.00)</description>
+		<year>1995</year>
+		<publisher>Tempest</publisher>
+		<info name="alt_title" value="アニメカ"/>
+		<info name="usage" value="Type AM to start the software."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="animecha - tempest (v2.00).dsk" size="737280" crc="f180882a" sha1="e2d52094582068a7c6b28949d1fd1803ef7d3873"/>
 			</dataarea>
 		</part>
 	</software>
@@ -18967,6 +19786,18 @@ HOMEBREW
 		</part>
 	</software>
 
+	<software name="copycat200">
+		<description>Copy CAT (Japan, v2.00)</description>
+		<year>1991</year>
+		<publisher>TAC</publisher>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="copy cat - tac (v2.00).dsk" size="737280" crc="606dacf3" sha1="7d4106bacfe3b6ba65d0812402d4468cd470a70d"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="coral2">
 		<description>Coral 2 (Netherlands, demo)</description>
 		<year>2004</year>
@@ -19159,6 +19990,18 @@ HOMEBREW
 		</part>
 	</software>
 
+	<software name="develop2">
+		<description>Developer II (Netherlands)</description>
+		<year>1989</year>
+		<publisher>MSX Gids</publisher>
+		<info name="usage" value="Requires a mouse."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="developer ii - msx gids.dsk" size="368640" crc="b7e86daf" sha1="b73528cccbf91cc18d8b557db39451036fc601e1"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="dimies">
 		<description>Dimies</description>
 		<year>1991</year>
@@ -19238,6 +20081,17 @@ HOMEBREW
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="368640">
 				<rom name="dizzy (1992)(msx engine).dsk" size="368640" crc="6599b9e7" sha1="6cdd2a0807030603edb940e108c908188f0f92a6"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dmkc63">
+		<description>DMK Creator (v6.3)</description>
+		<year>2017</year>
+		<publisher>Pirates do Caribe</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="dmk creator - pirates do caribe (v6.3).dsk" size="737280" crc="1ca5abc8" sha1="f485dd8a00ed2a7ac42f923d95bf0ea1f97ec98d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -19346,6 +20200,54 @@ HOMEBREW
 		</part>
 	</software>
 
+	<software name="dskpro116" supported="partial">
+		<description>DSKPRO (v11.6)</description>
+		<year>2017</year>
+		<publisher>Pirates do Caribe</publisher>
+		<notes>Does not start on all systems.</notes>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="dskpro - pirates do caribe (v11.6).dsk" size="737280" crc="03f2fd8f" sha1="2eaa5c57f3b14d3de2b372d246edb8154997f8f0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dskpro901" cloneof="dskpro116">
+		<description>DSKPRO (v9.01)</description>
+		<year>2015</year>
+		<publisher>Pirates do Caribe</publisher>
+		<info name="usage" value="Type DSKPRO to start the software."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="dskpro - pirates do caribe (v9.01).dsk" size="737280" crc="14e784f4" sha1="4bfdd4b3ffd94ffb7ffaf326ba54997cd11e0334"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dskpro651" cloneof="dskpro116">
+		<description>DSKPRO (v6.51)</description>
+		<year>2014</year>
+		<publisher>Pirates do Caribe</publisher>
+		<info name="usage" value="Type DSKPRO to start the software."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="dskpro - pirates do caribe (v6.51).dsk" size="737280" crc="615110d3" sha1="1fd811fae03ce5ffc611759bef46ca18b23d678a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dskproli">
+		<description>DSKPRO Light (v1.4)</description>
+		<year>2021</year>
+		<publisher>Pirates do Caribe</publisher>
+		<info name="usage" value="Type DSKPROLI to start the software."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="dskpro light - pirates do caribe (v1.4).dsk" size="737280" crc="69fa499b" sha1="4b151ed328ea54a33b5e07fe3867b3659869de29"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="ducktales">
 		<description>DuckTales (English)</description>
 		<year>1994</year>
@@ -19434,6 +20336,17 @@ HOMEBREW
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="eggbert (demo) (1993)(fony)(nl).dsk" size="737280" crc="66b950e0" sha1="fbd96d3b597da23ddf19af621204416404e1b185"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="eprom">
+		<description>EPROM - Extra Products ROM (Netherlands)</description>
+		<year>1996</year>
+		<publisher>UMF Noord-Holland</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="eprom - extra products rom - umf noord-holland.dsk" size="737280" crc="528c48b6" sha1="214d75561104e0565d242bec9f9bb7049a6c57e2"/>
 			</dataarea>
 		</part>
 	</software>
@@ -20642,6 +21555,17 @@ HOMEBREW
 		</part>
 	</software>
 
+	<software name="magedit">
+		<description>The Magical Editor (German)</description>
+		<year>1992</year>
+		<publisher>Sven Paschukat, Daniel Simon, Wolfgang Friedrich</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="the magical editor - paschukat-simon-friedrich.dsk" size="737280" crc="a9f2f6cb" sha1="d0d131566d79df7173eabb7db8f2aa416c1fd651"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="maglabrxdl">
 		<description>Magical Labyrinth Remix (Japan, download)</description>
 		<year>2020</year>
@@ -21099,6 +22023,17 @@ HOMEBREW
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="msx wars v - syntax.dsk" size="737280" crc="dd88e2f2" sha1="50cb33f65c3ec9bca387467425fad82dbc7dc645"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="msxutild">
+		<description>MSX Utility Disk (Netherlands)</description>
+		<year>1989</year>
+		<publisher>MSX Gids</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="368640">
+				<rom name="msx utility disk - msx gids.dsk" size="368640" crc="8c1b3c71" sha1="1d18240e15fe48d1cba180ea8b59a3ce5b65a590"/>
 			</dataarea>
 		</part>
 	</software>
@@ -21733,6 +22668,17 @@ HOMEBREW
 		</part>
 	</software>
 
+	<software name="protracker">
+		<description>Pro-tracker (Netherlands)</description>
+		<year>1991</year>
+		<publisher>Tyfoon Software</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1030984">
+				<rom name="pro-tracker - tyfoon software.dmk" size="1030984" crc="f646d462" sha1="0146d3522793e177164505424303aee0f69b7a1d"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="psychobl">
 		<description>Psycho Ball (Netherlands)</description>
 		<year>1993</year>
@@ -22243,6 +23189,42 @@ HOMEBREW
 		</part>
 	</software>
 
+	<software name="sampbox2">
+		<description>Sampbox 2 Deluxe (Netherlands)</description>
+		<year>199?</year>
+		<publisher>Z800</publisher>
+		<info name="usage" value="Requires MSX-AUDIO."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="sampboxc 2 deluxe - z800.dsk" size="737280" crc="deded64d" sha1="bfa65f7bf4351eb88dbc6311d2fdbce57a5af4e2"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sampbox3">
+		<description>Sampbox 3 Deluxe (Netherlands)</description>
+		<year>199?</year>
+		<publisher>Z800</publisher>
+		<info name="usage" value="Requires MSX-AUDIO."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="sampboxc 3 deluxe - z800.dsk" size="737280" crc="93da1dea" sha1="af8a09139911d38a5ae6a02359e1dc05a2cc5327"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sampbox4">
+		<description>Sampbox 4 Macro (Netherlands)</description>
+		<year>1994</year>
+		<publisher>N.O.P.</publisher>
+		<info name="usage" value="Requires MSX-AUDIO."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="sampboxc 4 macro - n.o.p.dsk" size="737280" crc="b51bf3f7" sha1="3a00b4adf8c1756a4973b57174169d9e003151d3"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="sanriku0">
 		<description>Sanriku Ouja #0 (Japan)</description>
 		<year>1997</year>
@@ -22701,6 +23683,17 @@ HOMEBREW
 		</part>
 	</software>
 
+	<software name="studiofm">
+		<description>Studio FM (Netherlands)</description>
+		<year>1991</year>
+		<publisher>MSX-Engine</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1032280">
+				<rom name="studio fm - msx-engine.dmk" size="1032280" crc="65950dbc" sha1="0f2b4b1633fd2239bc71b1de7bdc40fccda67c60"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="summishm">
 		<description>Sum the Missile Human (Japan)</description>
 		<year>1989</year>
@@ -22721,6 +23714,29 @@ HOMEBREW
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
 				<rom name="super_dynamite_fighters_street.dsk" size="737280" crc="8c30cc16" sha1="a99c26cfdac12db8c000bdd8b0dc333803199988"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="superx12">
+		<description>Super-X (Japan, v1.2)</description>
+		<year>1994</year>
+		<publisher>Romi</publisher>
+		<info name="usage" value="To enter the software type _@. Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="super-x - romi (v1.2).dsk" size="737280" crc="61ce60ca" sha1="06d16a5168b0bd0a686137c0d74cb55ff7a0f12c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="synchroc">
+		<description>Synchro Copy</description>
+		<year>1993</year>
+		<publisher>E.I Soft</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="synchro copy - e.i soft.dsk" size="737280" crc="8f7f196f" sha1="8ee37683174060e24753d0eaebaf8a9c36d21a98"/>
 			</dataarea>
 		</part>
 	</software>
@@ -22911,6 +23927,33 @@ HOMEBREW
 		</part>
 	</software>
 
+	<software name="traxplayer" supported="no">
+		<description>TraxPlayer</description>
+		<year>1994</year>
+		<publisher>N.O.P.</publisher>
+		<notes>Loading from example disks results in errors.</notes>
+		<info name="usage" value="Requires MSX-AUDIO. Requires 256KB RAM."/>
+		<part name="flop1" interface="floppy_3_5">
+			<!-- No photographic evidence for this part id -->
+			<feature name="part_id" value="Editor"/>
+			<dataarea name="flop" size="737280">
+				<rom name="traxplayer - n.o.p. (disk 1).dsk" size="737280" crc="b6c2dfdc" sha1="d9911bf4437244c1db4f921bdf36bbcdf012d40c"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Example disk 1"/>
+			<dataarea name="flop" size="737280">
+				<rom name="traxplayer - n.o.p. (disk 2).dsk" size="737280" crc="b1693a0a" sha1="c043124bcb337d065df268d288b44f7690fe119e"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Example disk 2"/>
+			<dataarea name="flop" size="737280">
+				<rom name="traxplayer - n.o.p. (disk 3).dsk" size="737280" crc="74bdb5e7" sha1="8ed224ae616ce8ce7efda0fed45452d09ce360fa"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="trojka">
 		<description>Trojka (Netherlands)</description>
 		<year>1992</year>
@@ -23016,6 +24059,18 @@ HOMEBREW
 		</part>
 	</software>
 
+	<software name="twincopy">
+		<description>TwinCopy (Japan)</description>
+		<year>1991</year>
+		<publisher>P.T.O.</publisher>
+		<info name="usage" value="Requires a Japanese system."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="twincopy - p.t.o..dsk" size="737280" crc="d143c16f" sha1="5af95f3799e7aa3038babcd0e248bd8f5d494bc2"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="uhfpaint">
 		<description>The UHF Painter (Italy)</description>
 		<year>1992</year>
@@ -23033,8 +24088,8 @@ HOMEBREW
 		<publisher>MSX Club West Friesland</publisher>
 		<notes>Requires two MSX computers to be connected through joystick ports using a joynet cable.</notes>
 		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="veldslag - mcwf.dsk" size="368640" crc="808e0403" sha1="816ea85708c36e5162b6340e34de5a3f2f0fe67c"/>
+			<dataarea name="flop" size="1046008">
+				<rom name="veldslag - mcwf.dmk" size="1046008" crc="d50105b8" sha1="3279368358380c412f0de92963f41bc83f0429f6"/>
 			</dataarea>
 		</part>
 	</software>
@@ -23232,8 +24287,8 @@ HOMEBREW
 		<publisher>MSX Club West Friesland</publisher>
 		<notes>Requires two MSX computers to be connected through joystick ports using a joynet cable.</notes>
 		<part name="flop1" interface="floppy_3_5">
-			<dataarea name="flop" size="368640">
-				<rom name="zeeslag - mcwf.dsk" size="368640" crc="bb4ff65b" sha1="4357c1e0f7ae559ab8ceb8169a689fb4cd0d8f1f"/>
+			<dataarea name="flop" size="1046008">
+				<rom name="zeeslag - mcwf.dmk" size="1046008" crc="95a88052" sha1="709661c0c421c40a6eb733d5bdae8034610c9425"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/saturn.xml
+++ b/hash/saturn.xml
@@ -2594,6 +2594,7 @@ Olympic Soccer (Fra) T-7904H-09
 		<description>Alien Trilogy (Japan)</description>
 		<year>1996</year>
 		<publisher>Acclaim Japan</publisher>
+		<info name="language" value="Japanese" />
 		<info name="serial" value="T-8113G"/>
 		<info name="release" value="19960830"/>
 		<info name="alt_title" value="エイリアントリロジー"/>
@@ -9675,6 +9676,7 @@ Sega logo animation draws offset [VDP2]
 		<description>Alien Trilogy (Japan, alt)</description>
 		<year>1996</year>
 		<publisher>Acclaim Japan</publisher>
+		<info name="language" value="Japanese" />
 		<info name="serial" value="T-8113G"/>
 		<info name="release" value="19960830"/>
 		<info name="alt_title" value="エイリアントリロジー"/>
@@ -14946,6 +14948,7 @@ Sega logo animation draws offset [VDP2]
 		<description>Alien Trilogy (Japan, alt 2)</description>
 		<year>1996</year>
 		<publisher>Acclaim Japan</publisher>
+		<info name="language" value="Japanese" />
 		<info name="serial" value="T-8113G"/>
 		<info name="release" value="19960830"/>
 		<info name="alt_title" value="エイリアントリロジー"/>
@@ -30198,6 +30201,7 @@ Sega logo animation draws offset [VDP2]
 		<description>Alien Trilogy (Europe)</description>
 		<year>1996</year>
 		<publisher>Acclaim Entertainment</publisher>
+		<info name="language" value="English/French/Italian/Spanish" />
 		<info name="serial" value="T-8113H-50"/>
 		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="cdrom" interface="sat_cdrom">
@@ -30212,6 +30216,7 @@ Sega logo animation draws offset [VDP2]
 		<description>Alien Trilogy (Germany)</description>
 		<year>1996</year>
 		<publisher>Acclaim Entertainment</publisher>
+		<info name="language" value="German" />
 		<info name="serial" value="T-8113H-18"/>
 		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="cdrom" interface="sat_cdrom">
@@ -34286,7 +34291,7 @@ Sega logo animation draws offset [VDP2]
 
 	<!-- Identifying CRIMEWAVE_demo... -->
 	<software name="crimewavd" cloneof="crimewav" supported="no">
-		<description>CrimeWave Playable Demonstration Disk (Europe)</description>
+		<description>CrimeWave Playable Demonstration Disk - Not For Resale (Europe)</description>
 		<year>1997</year>
 		<publisher>Eidos</publisher>
 		<info name="serial" value="610-6455"/>
@@ -34716,6 +34721,7 @@ Sega logo animation draws offset [VDP2]
 		<description>Alien Trilogy (USA)</description>
 		<year>1996</year>
 		<publisher>Acclaim Entertainment</publisher>
+		<info name="language" value="Japanese" />
 		<info name="serial" value="T-8113H"/>
 		<info name="release" value="199607xx"/>
 		<sharedfeat name="compatibility" value="NTSC-U"/>
@@ -37208,7 +37214,7 @@ Sega logo animation draws offset [VDP2]
 	</software>
 
 	<!-- Identifying dw-sat-0856-Rayman-usa... -->
-	<software name="raymanu" supported="no">
+	<software name="raymanu" cloneof="rayman" supported="no">
 		<description>Rayman (USA)</description>
 		<year>1995</year>
 		<publisher>Ubi Soft</publisher>
@@ -39099,7 +39105,7 @@ Sega logo animation draws offset [VDP2]
 	<!-- input / output cue/bin verified identical as of CHDMAN change made around 28th Dec 2015, except for
 	   the 'ISRC 904002100272' metadata line after 'TRACK 24 AUDIO' being ommitted from the cuesheet, we don't
 	   store that information -->
-	<software name="raymanp" supported="no"> <!-- the header lists 19950424, but elsewhere there are date stamps of 19950720 -->
+	<software name="raymanp" cloneof="rayman" supported="no"> <!-- the header lists 19950424, but elsewhere there are date stamps of 19950720 -->
 		<description>Rayman (prototype 19950720)</description>
 		<year>1995</year>
 		<publisher>Ubi Soft</publisher>

--- a/src/devices/cpu/mips/mips1.cpp
+++ b/src/devices/cpu/mips/mips1.cpp
@@ -237,7 +237,7 @@ mips1_device_base::mips1_device_base(machine_config const &mconfig, device_type 
 }
 
 r2000_device::r2000_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock, size_t icache_size, size_t dcache_size)
-	: mips1_device_base(mconfig, R2000, tag, owner, clock, 0x0100, icache_size, dcache_size, false)
+	: mips1_device_base(mconfig, R2000, tag, owner, clock, 0x0120, icache_size, dcache_size, false)
 {
 }
 

--- a/src/devices/cpu/palm/palm.h
+++ b/src/devices/cpu/palm/palm.h
@@ -22,6 +22,7 @@ public:
 
 	auto getb_bus() { return m_getb_bus.bind(); }
 	auto select_ros() { return m_select_ros.bind(); }
+	auto program_level() { return m_program_level.bind(); }
 
 	palm_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock);
 
@@ -62,6 +63,7 @@ private:
 
 	devcb_write8 m_getb_bus;
 	devcb_write_line m_select_ros;
+	devcb_write_line m_program_level;
 
 	// mame state
 	int m_icount;

--- a/src/mame/atari/harddriv.cpp
+++ b/src/mame/atari/harddriv.cpp
@@ -1310,7 +1310,7 @@ static INPUT_PORTS_START( strtdriv )
 	PORT_BIT( 0x0800, IP_ACTIVE_LOW, IPT_BUTTON2 )  /* ??? */
 	PORT_BIT( 0x1000, IP_ACTIVE_LOW, IPT_BUTTON3 )  /* ??? */
 	PORT_BIT( 0x2000, IP_ACTIVE_LOW, IPT_UNUSED )
-	PORT_BIT( 0x4000, IP_ACTIVE_LOW, IPT_CUSTOM )  /*??? */
+	PORT_BIT( 0x4000, IP_ACTIVE_LOW, IPT_CUSTOM )  /* center edge on steering wheel */
 	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_START("mainpcb:8BADC.0")        /* b00000 - 8 bit ADC 0 - gas pedal */
@@ -1400,7 +1400,7 @@ static INPUT_PORTS_START( hdrivair )
 	PORT_BIT( 0x0800, IP_ACTIVE_LOW, IPT_BUTTON2 ) 	PORT_NAME("Wings 1")
 	PORT_BIT( 0x1000, IP_ACTIVE_LOW, IPT_BUTTON3 )  PORT_NAME("Wings 1")
 	PORT_BIT( 0x2000, IP_ACTIVE_LOW, IPT_UNUSED )
-	PORT_BIT( 0x4000, IP_ACTIVE_LOW, IPT_CUSTOM )  /* center edge on steering wheel, if you add a PORT_NAME to this then asign a button to it you can reset the steering center point but only in the test menu........ */
+	PORT_BIT( 0x4000, IP_ACTIVE_LOW, IPT_CUSTOM )  /* center edge on steering wheel */
 	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_UNUSED )
 
 	PORT_START("mainpcb:8BADC.0")        /* b00000 - 8 bit ADC 0 - gas pedal */

--- a/src/mame/atari/harddriv.cpp
+++ b/src/mame/atari/harddriv.cpp
@@ -1394,11 +1394,11 @@ static INPUT_PORTS_START( hdrivair )
 	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_START1 )   /* start */
 	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_COIN3 )    /* aux coin */
 	PORT_BIT( 0x00f8, IP_ACTIVE_LOW, IPT_UNUSED )
-	PORT_BIT( 0x0100, IP_ACTIVE_LOW, IPT_BUTTON5 )	PORT_NAME("3D Object Viewer")
-	PORT_BIT( 0x0200, IP_ACTIVE_LOW, IPT_BUTTON4 )  PORT_TOGGLE PORT_NAME("Reverse")
-	PORT_BIT( 0x0400, IP_ACTIVE_LOW, IPT_BUTTON6 )	PORT_NAME("World State Screen")
+	PORT_BIT( 0x0100, IP_ACTIVE_LOW, IPT_BUTTON5 )	PORT_NAME("3D Object Viewer")  /* holding down the button brings up the 3D Object Viewer in attract mode */
+	PORT_BIT( 0x0200, IP_ACTIVE_LOW, IPT_BUTTON4 )  PORT_NAME("Reverse")
+	PORT_BIT( 0x0400, IP_ACTIVE_LOW, IPT_BUTTON6 )	PORT_NAME("World State Screen")  /* activates sound test in attract mode but activates world state screen while in game */
 	PORT_BIT( 0x0800, IP_ACTIVE_LOW, IPT_BUTTON2 ) 	PORT_NAME("Wings 1")
-	PORT_BIT( 0x1000, IP_ACTIVE_LOW, IPT_BUTTON3 )  PORT_NAME("Wings 1")
+	PORT_BIT( 0x1000, IP_ACTIVE_LOW, IPT_BUTTON3 )  PORT_NAME("Wings 2")
 	PORT_BIT( 0x2000, IP_ACTIVE_LOW, IPT_UNUSED )
 	PORT_BIT( 0x4000, IP_ACTIVE_LOW, IPT_CUSTOM )  /* center edge on steering wheel */
 	PORT_BIT( 0x8000, IP_ACTIVE_LOW, IPT_UNUSED )

--- a/src/mame/capcom/mitchell.cpp
+++ b/src/mame/capcom/mitchell.cpp
@@ -2191,6 +2191,40 @@ ROM_START( pkladiesbl )
 	ROM_LOAD("3.ic127", 0x000000, 0x20000, CRC(16b79788) SHA1(6b796119d3c57229ba3d613ce8832c94e9616f76) )
 ROM_END
 
+ROM_START( pkladiesblu )  // uncensored encrypted bootleg. ROMs 1, 2, 3, 16 & 17 are identical to set pkladiesbl
+	ROM_REGION( 0x50000*2, "maincpu", 0 )
+	// only pklbu1.bin is encrypted (only opcodes). Encryption scheme seems to involve XORs and bitswaps, based on addresses.
+	ROM_LOAD( "pklbu1.bin", 0x50000, 0x08000, CRC(ca4cfaf9) SHA1(97ad3c526e4494f347db45c986ba23aff07e6321) )
+	ROM_CONTINUE(0x00000,0x08000)
+	ROM_LOAD( "pklbu2.bin", 0x60000, 0x10000, CRC(5c73e9b6) SHA1(5fbfb4c79e2df8e1edd3f29ac63f9961dd3724b1) )
+	ROM_CONTINUE(0x10000,0x10000)
+
+	ROM_REGION( 0x240000, "chars", ROMREGION_INVERT )
+	ROM_LOAD32_BYTE("pklbu20.bin", 0x000000, 0x20000, CRC(1f537087) SHA1(87ea5bee67bb2a1f8bbe191ed3e8a83491a3cd0f) )
+	ROM_LOAD32_BYTE("pklbu14.bin", 0x000001, 0x20000, CRC(3fd2684d) SHA1(0f14cce27551af64ccc607fa14689cfceb0bb367) )
+	ROM_LOAD32_BYTE("pklbu10.bin", 0x000002, 0x20000, CRC(97424238) SHA1(9c3ef3d5524133ba79929318288010ec5a15641a) )
+	ROM_LOAD32_BYTE("pklbu6.bin",  0x000003, 0x20000, CRC(96c7eed0) SHA1(d435e6785cc447bee538dc89c1cbbe84071301d8) )
+	ROM_LOAD32_BYTE("pklbu21.bin", 0x080000, 0x20000, CRC(6c18df0d) SHA1(eef87c710bbb2f643a7ea8ba2b2f609fb663b579) )
+	ROM_LOAD32_BYTE("pklbu15.bin", 0x080001, 0x20000, CRC(0a52206a) SHA1(68f2aa9cda53fb9d545fd5ec29ac7e1ccf0faac7) )
+	ROM_LOAD32_BYTE("pklbu11.bin", 0x080002, 0x20000, CRC(7f995c59) SHA1(cb533d524dd35d1058cb319e8f7b60c9d675c858) )
+	ROM_LOAD32_BYTE("pklbu7.bin",  0x080003, 0x20000, CRC(d6a7a95b) SHA1(2a4b4ed65dbca88d38f5977f49b6800f8adc519b) )
+	ROM_LOAD32_BYTE("pklbu18.bin", 0x100000, 0x20000, CRC(1280a069) SHA1(e2622f528d08eb05dd178fda003b4648828eaf06) )
+	ROM_LOAD32_BYTE("pklbu12.bin", 0x100001, 0x20000, CRC(09aa3215) SHA1(d8bfd9eeba33e5b965b6f10421cfee675c44cd61) )
+	ROM_LOAD32_BYTE("pklbu8.bin",  0x100002, 0x20000, CRC(2132c239) SHA1(fd770fc212476d32e08e2fae3af3fa42bce5abe2) )
+	ROM_LOAD32_BYTE("pklbu4.bin",  0x100003, 0x20000, CRC(b798d926) SHA1(de21e5efff32ef421f68545ccbddfb18db54436b) )
+	ROM_LOAD32_BYTE("pklbu19.bin", 0x180000, 0x20000, CRC(95d838cf) SHA1(179634dc6628f858e3f099070604599257aafbe9) )
+	ROM_LOAD32_BYTE("pklbu13.bin", 0x180001, 0x20000, CRC(10be806b) SHA1(36cc07a93412be2a0e90bcc133b52febfed8bd90) )
+	ROM_LOAD32_BYTE("pklbu9.bin",  0x180002, 0x20000, CRC(9059d383) SHA1(5e8a5a6079838b51363c3a763475b9ca4326d598) )
+	ROM_LOAD32_BYTE("pklbu5.bin",  0x180003, 0x20000, CRC(8819affb) SHA1(095d951fa77ae09c4a68c4d971f532c517cb295a) )
+
+	ROM_REGION( 0x040000, "sprites", ROMREGION_INVERT )
+	ROM_LOAD("pklbu16.bin", 0x020000, 0x20000, CRC(c6decb5e) SHA1(3d35cef348deb16a62a066acdfbabebcf11fa997) )
+	ROM_LOAD("pklbu17.bin", 0x000000, 0x20000, CRC(5a6efdcc) SHA1(04120dd4da0ff8df514f98a44d7eee7100e4c033) )
+
+	ROM_REGION( 0x80000, "oki", 0 )
+	ROM_LOAD("pklbu13.bin", 0x000000, 0x20000, CRC(16b79788) SHA1(6b796119d3c57229ba3d613ce8832c94e9616f76) )
+ROM_END
+
 ROM_START( pkladiesbl2 ) // same as the above but without the z80 block, only 1.ic112 differs
 	ROM_REGION( 0x50000*2, "maincpu", 0 )
 	ROM_LOAD( "1.ic112", 0x50000, 0x08000, CRC(cadb9925) SHA1(d88353501a29ff855335f9c8822e095ef5196246) ) //sldh
@@ -3264,7 +3298,8 @@ GAME( 1989, mgakuen2,    0,        marukin,    marukin,    mitchell_state,   ini
 GAME( 1989, pkladies,    0,        marukin,    pkladies,   mitchell_state,   init_pkladies,   ROT0,   "Mitchell",                  "Poker Ladies", MACHINE_SUPPORTS_SAVE )
 GAME( 1989, pkladiesl,   pkladies, marukin,    pkladies,   mitchell_state,   init_pkladies,   ROT0,   "Leprechaun",                "Poker Ladies (Leprechaun ver. 510)", MACHINE_SUPPORTS_SAVE )
 GAME( 1989, pkladiesla,  pkladies, marukin,    pkladies,   mitchell_state,   init_pkladies,   ROT0,   "Leprechaun",                "Poker Ladies (Leprechaun ver. 401)", MACHINE_SUPPORTS_SAVE )
-GAME( 1989, pkladiesbl,  pkladies, pkladiesbl, pkladiesbl, pkladiesbl_state, init_pkladiesbl, ROT0,   "bootleg",                   "Poker Ladies (Censored bootleg, encrypted)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // by Playmark? need to figure out CPU 'decryption' / ordering
+GAME( 1989, pkladiesbl,  pkladies, pkladiesbl, pkladiesbl, pkladiesbl_state, init_pkladiesbl, ROT0,   "bootleg",                   "Poker Ladies (Censored bootleg, encrypted)",     MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // by Playmark? need to figure out CPU 'decryption' / ordering
+GAME( 1989, pkladiesblu, pkladies, pkladiesbl, pkladiesbl, pkladiesbl_state, init_pkladiesbl, ROT0,   "bootleg",                   "Poker Ladies (Uncensored bootleg, encrypted)",   MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // by Playmark? need to figure out CPU 'decryption' / ordering
 GAME( 1989, pkladiesbl2, pkladies, pkladiesbl, pkladiesbl, pkladiesbl_state, init_pkladiesbl, ROT0,   "bootleg",                   "Poker Ladies (Censored bootleg, not encrypted)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND ) // by Playmark? needs inputs, EEPROM (?), MSM5205 hook up, GFX fixes
 
 GAME( 1989, dokaben,     0,        pang,       pang,       mitchell_state,   init_dokaben,    ROT0,   "Capcom",                    "Dokaben (Japan)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/ibm/ibm5100.cpp
+++ b/src/mame/ibm/ibm5100.cpp
@@ -51,6 +51,7 @@ public:
 	{
 	}
 
+	void common(machine_config &config);
 	void ibm5100(machine_config &config);
 
 protected:
@@ -263,7 +264,7 @@ void ibm5100_state::cpu_iod_map(address_map &map)
 	map(0xf, 0xf).noprw();
 }
 
-void ibm5100_state::ibm5100(machine_config &config)
+void ibm5100_state::common(machine_config &config)
 {
 	PALM(config, m_cpu, 15'091'200);
 	m_cpu->set_addrmap(palm_device::AS_ROS, &ibm5100_state::cpu_ros_map);
@@ -281,6 +282,11 @@ void ibm5100_state::ibm5100(machine_config &config)
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_raw(15'091'200, 64*10+15, 0, 64*10, 16*12*2, 0, 16*12*2);
 	m_screen->set_screen_update(FUNC(ibm5100_state::screen_update));
+}
+
+void ibm5100_state::ibm5100(machine_config &config)
+{
+	ibm5100_state::common(config);
 
 	IBM5100_KEYBOARD(config, m_kbd);
 	m_kbd->strobe().set(
@@ -293,7 +299,7 @@ void ibm5100_state::ibm5100(machine_config &config)
 
 void ibm5110_state::ibm5110(machine_config &config)
 {
-	ibm5100_state::ibm5100(config);
+	ibm5100_state::common(config);
 
 	m_cpu->program_level().set(
 		[this](int state)
@@ -304,7 +310,7 @@ void ibm5110_state::ibm5110(machine_config &config)
 				m_exr.select(BIT(m_lang->read(), 6));
 		});
 
-	IBM5110_KEYBOARD(config.replace(), m_kbd);
+	IBM5110_KEYBOARD(config, m_kbd);
 	m_kbd->strobe().set(
 		[this](int state)
 		{

--- a/src/mame/ibm/ibm5100.cpp
+++ b/src/mame/ibm/ibm5100.cpp
@@ -11,10 +11,11 @@
  *  - display registers
  *  - device address f
  *  - tape controller
+ *  - disk controller
  *  - printer
  *  - communications cards
  *  - expansion feature
- *  - later models (5110, 5120, 5130)
+ *  - feature ROS (K4)
  */
 
 #include "emu.h"
@@ -22,8 +23,11 @@
 #include "ibm5100_kbd.h"
 
 #include "cpu/palm/palm.h"
+#include "sound/beep.h"
 
+#include "emupal.h"
 #include "screen.h"
+#include "speaker.h"
 
 //#define VERBOSE (LOG_GENERAL)
 #include "logmacro.h"
@@ -38,12 +42,12 @@ public:
 		, m_cpu(*this, "cpu")
 		, m_screen(*this, "screen")
 		, m_kbd(*this, "kbd")
-		, m_nxr(*this, { "apl", "basic" })
-		, m_j2(*this, "j2")
+		, m_nxr(*this, { "common", "basic", "apl" })
+		, m_cgr(*this, "cgr")
+		, m_ros(*this, "ros")
 		, m_conf(*this, "CONF")
 		, m_disp(*this, "DISP")
 		, m_lang(*this, "LANG")
-		, m_ros(*this, "ros")
 	{
 	}
 
@@ -54,59 +58,110 @@ protected:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
-	void cpu_ros_map(address_map &map);
-	void cpu_rws_map(address_map &map);
-	void cpu_ioc_map(address_map &map);
-	void cpu_iod_map(address_map &map);
+	virtual void cpu_ros_map(address_map &map);
+	virtual void cpu_rws_map(address_map &map);
+	virtual void cpu_ioc_map(address_map &map);
+	virtual void cpu_iod_map(address_map &map);
 
 	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, rectangle const &cliprect);
 
-	// e2 - ros control card
-	u8 e2_sts_r();
-	void e2_ctl_w(u8 data);
-	u8 e2_r();
-	void e2_w(u8 data);
+	virtual void da0_ctl_w(u8 data);
 
-	// f2 - base i/o card
-	u8 f2_kbd_sts_r();
-	void f2_kbd_ctl_w(u8 data);
-	void da0_ctl_w(u8 data);
+	// non-executable ROS control
+	u8 nxr_sts_r();
+	void nxr_ctl_w(u8 data);
+	virtual u8 nxr_r();
+	virtual void nxr_w(u8 data);
+
+	// keyboard
+	u8 kbd_sts_r();
+	void kbd_ctl_w(u8 data);
+
 	void daf_ctl_w(u8 data);
 
-private:
 	required_device<palm_device> m_cpu;
 	required_device<screen_device> m_screen;
 	required_device<ibm5100_keyboard_device> m_kbd;
 
-	required_region_ptr_array<u16, 2> m_nxr;
-	required_region_ptr<u8> m_j2;
+	required_region_ptr_array<u16, 3> m_nxr;
+	required_region_ptr<u8> m_cgr; // character generator ROS
+
+	memory_view m_ros;
 
 	required_ioport m_conf;
 	required_ioport m_disp;
 	required_ioport m_lang;
 
-	memory_view m_ros;
-
 	u8 m_getb_bus;
 
-	u8 m_e2_ff; // e2 card flip-flops
-	u8 m_f2_ff; // f2 card flip-flops
-	u16 m_e2_address;
+	u8 m_nxr_ff; // non-executable ROS control flip-flops
+	u8 m_bio_ff; // base I/O card flip-flops
+	u16 m_nxr_address;
 
 	std::unique_ptr<u16[]> m_rws;
 };
 
-enum e2_ff_mask : u8
+class ibm5110_state : public ibm5100_state
 {
-	E2_RS = 0x01, // ROS select (0=APL, 1=BASIC/common)
-	E2_PS = 0x02, // put strobe
-	E2_B0 = 0x04, // data address bit 0
+public:
+	ibm5110_state(machine_config const &mconfig, device_type type, char const *tag)
+		: ibm5100_state(mconfig, type, tag)
+		, m_alarm(*this, "alarm")
+		, m_exr(*this, "exr")
+		, m_jmp(*this, { "L2_1", "L2_2", "K4" })
+	{
+	}
+
+	void ibm5110(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+	virtual void cpu_ros_map(address_map &map) override;
+	virtual void cpu_ioc_map(address_map &map) override;
+
+	virtual void da0_ctl_w(u8 data) override;
+
+	// executable ROS control
+	u8 exr_sts_r();
+	void exr_ctl_w(u8 data);
+
+	// non-executable ROS control
+	virtual u8 nxr_r() override;
+	virtual void nxr_w(u8 data) override;
+
+private:
+	required_device<beep_device> m_alarm;
+
+	memory_view m_exr;
+
+	required_ioport_array<3> m_jmp;
+
+	u8 m_exr_ff; // executable ROS flip-flops
 };
 
-enum f2_ff_mask : u8
+enum nxr_ff_mask : u8
 {
-	F2_KIE = 0x01, // keyboard interrupt enable
-	F2_DO  = 0x10, // display off
+	NXR_RS     = 0x03, // ROS select
+	NXR_PS     = 0x04, // put strobe
+	NXR_B0     = 0x08, // data address bit 0
+
+	NXR_COMMON = 0x00,
+	NXR_BASIC  = 0x01,
+	NXR_APL    = 0x02,
+};
+
+enum bio_ff_mask : u8
+{
+	BIO_KIE = 0x01, // keyboard interrupt enable
+	BIO_KI  = 0x08, // keyboard interrupt active
+	BIO_DO  = 0x10, // display off
+};
+
+enum exr_ff_mask : u8
+{
+	EXR_ROS2 = 0x01, // ROS2 enable
 };
 
 void ibm5100_state::machine_start()
@@ -116,19 +171,26 @@ void ibm5100_state::machine_start()
 
 	save_item(NAME(m_getb_bus));
 
-	save_item(NAME(m_e2_ff));
-	save_item(NAME(m_f2_ff));
-	save_item(NAME(m_e2_address));
+	save_item(NAME(m_nxr_ff));
+	save_item(NAME(m_bio_ff));
+	save_item(NAME(m_nxr_address));
 
 	save_pointer(NAME(m_rws), 0x8000);
 }
 
+void ibm5110_state::machine_start()
+{
+	ibm5100_state::machine_start();
+
+	save_item(NAME(m_exr_ff));
+}
+
 void ibm5100_state::machine_reset()
 {
-	m_e2_ff = 0;
-	m_f2_ff = 0;
+	m_nxr_ff = 0;
+	m_bio_ff = 0;
 
-	m_e2_address = 0;
+	m_nxr_address = 0;
 
 	// install configured rws
 	unsigned const rws_cards = (m_conf->read() & 3) + 1;
@@ -136,10 +198,27 @@ void ibm5100_state::machine_reset()
 	m_ros[1].install_ram(0x80, 0x4000 * rws_cards - 1, &m_rws[0x40]);
 }
 
+void ibm5110_state::machine_reset()
+{
+	ibm5100_state::machine_reset();
+
+	m_exr.disable();
+	m_exr_ff = 0;
+}
+
 void ibm5100_state::cpu_ros_map(address_map &map)
 {
 	map(0x0000, 0xffff).view(m_ros);
 	m_ros[0](0x0000, 0xffff).rom().region("ros", 0);
+}
+
+void ibm5110_state::cpu_ros_map(address_map &map)
+{
+	map(0x0000, 0xffff).view(m_ros);
+	m_ros[0](0x0000, 0x7fff).rom().region("l2_1", 0);
+	m_ros[0](0x0000, 0x7fff).view(m_exr);
+	m_exr[0](0x0000, 0x7fff).rom().region("l2_2a", 0);
+	m_exr[1](0x0000, 0x7fff).rom().region("l2_2b", 0);
 }
 
 void ibm5100_state::cpu_rws_map(address_map &map)
@@ -150,9 +229,9 @@ void ibm5100_state::cpu_rws_map(address_map &map)
 void ibm5100_state::cpu_ioc_map(address_map &map)
 {
 	map(0x0, 0x0).w(FUNC(ibm5100_state::da0_ctl_w));
-	map(0x1, 0x1).rw(FUNC(ibm5100_state::e2_sts_r), FUNC(ibm5100_state::e2_ctl_w));
+	map(0x1, 0x1).rw(FUNC(ibm5100_state::nxr_sts_r), FUNC(ibm5100_state::nxr_ctl_w));
 	map(0x2, 0x3).noprw();
-	map(0x4, 0x4).rw(FUNC(ibm5100_state::f2_kbd_sts_r), FUNC(ibm5100_state::f2_kbd_ctl_w));
+	map(0x4, 0x4).rw(FUNC(ibm5100_state::kbd_sts_r), FUNC(ibm5100_state::kbd_ctl_w));
 	// 5 printer r:not used w:control
 	map(0x6, 0x7).noprw();
 	// 8 expansion r:status w:control
@@ -161,14 +240,21 @@ void ibm5100_state::cpu_ioc_map(address_map &map)
 	map(0xf, 0xf).nopr().w(FUNC(ibm5100_state::daf_ctl_w));
 }
 
+void ibm5110_state::cpu_ioc_map(address_map &map)
+{
+	ibm5100_state::cpu_ioc_map(map);
+
+	map(0x2, 0x2).rw(FUNC(ibm5110_state::exr_sts_r), FUNC(ibm5110_state::exr_ctl_w));
+}
+
 void ibm5100_state::cpu_iod_map(address_map &map)
 {
 	map.unmap_value_high();
 
 	map(0x0, 0x0).noprw();
-	map(0x1, 0x1).rw(FUNC(ibm5100_state::e2_r), FUNC(ibm5100_state::e2_w));
+	map(0x1, 0x1).rw(FUNC(ibm5100_state::nxr_r), FUNC(ibm5100_state::nxr_w));
 	map(0x2, 0x3).noprw();
-	map(0x4, 0x4).r(m_kbd, FUNC(ibm5100_keyboard_device::read)).nopw();
+	map(0x4, 0x4).r(m_kbd, FUNC(ibm5100_keyboard_device::read));
 	// 5 r:printer w:print data
 	map(0x6, 0x7).noprw();
 	// 8 expansion r:not used w:data
@@ -193,16 +279,64 @@ void ibm5100_state::ibm5100(machine_config &config)
 	 * pixels of each character cell line and every other scan line are blank.
 	 */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
-	m_screen->set_raw(15'091'200, 64*10, 0, 64*10, 16*12*2, 0, 16*12*2);
+	m_screen->set_raw(15'091'200, 64*10+15, 0, 64*10, 16*12*2, 0, 16*12*2);
 	m_screen->set_screen_update(FUNC(ibm5100_state::screen_update));
 
 	IBM5100_KEYBOARD(config, m_kbd);
 	m_kbd->strobe().set(
 		[this](int state)
 		{
-			if ((m_f2_ff & F2_KIE) && !state)
+			if ((m_bio_ff & BIO_KIE) && !state)
 				m_cpu->set_input_line(palm_device::IRPT_REQ3, 0);
 		});
+}
+
+void ibm5110_state::ibm5110(machine_config &config)
+{
+	ibm5100_state::ibm5100(config);
+
+	m_cpu->program_level().set(
+		[this](int state)
+		{
+			if (state || !(m_exr_ff & EXR_ROS2))
+				m_exr.disable();
+			else
+				m_exr.select(BIT(m_lang->read(), 6));
+		});
+
+	IBM5110_KEYBOARD(config.replace(), m_kbd);
+	m_kbd->strobe().set(
+		[this](int state)
+		{
+			if (!state)
+			{
+				m_bio_ff |= BIO_KI;
+
+				if (m_bio_ff & BIO_KIE)
+					m_cpu->set_input_line(palm_device::IRPT_REQ3, 0);
+			}
+		});
+
+	SPEAKER(config, "mono").front_center();
+	BEEP(config, m_alarm, 3'885); // FIXME: frequency
+	m_alarm->add_route(ALL_OUTPUTS, "mono", 0.25);
+
+	// gfxdecode is only used to show the font data in the tile viewer
+	static const gfx_layout g2_layout =
+	{
+		8, 12, 256, 1,
+		{ 0 },
+		{ 0, 1, 2, 3, 4, 5, 6, 7 },
+		{ 0 * 8, 1 * 8, 2 * 8, 3 * 8, 4 * 8, 5 * 8, 6 * 8, 7 * 8, 8 * 8, 9 * 8, 10 * 8, 11 * 8 },
+		8 * 16
+	};
+
+	static GFXDECODE_START(g2)
+		GFXDECODE_ENTRY("cgr", 0, g2_layout, 0, 1)
+	GFXDECODE_END
+
+	PALETTE(config, "palette", palette_device::MONOCHROME);
+	GFXDECODE(config, "gfx", "palette", g2);
 }
 
 u32 ibm5100_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, rectangle const &cliprect)
@@ -219,11 +353,14 @@ u32 ibm5100_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, re
 	// start with a blank screen
 	bitmap.fill(c[reverse]);
 
-	// then generate characters
+	if (m_bio_ff & BIO_DO)
+		return 0;
+
+	// generate characters
 	auto const rws = util::big_endian_cast<u8 const>(m_rws.get());
 	for (unsigned char_y = 0; char_y < 16; char_y++)
 	{
-		// every other scan line is blank
+		// every alternate scan line is blank
 		int const y = screen.visible_area().min_y + char_y * 12 * 2;
 
 		// compute offset into rws for each row
@@ -233,17 +370,31 @@ u32 ibm5100_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, re
 		{
 			int const x = screen.visible_area().min_x + char_x * 10;
 
-			// read next character if display is on and normal mode or even column
+			// read next character if normal mode or even column
 			u8 char_data = 0;
-			if (!(m_f2_ff & F2_DO) && (n64 || !(char_x & 1)))
+			if (n64 || !(char_x & 1))
 				char_data = rws[offset++];
 
 			// draw 8x12 character cell
 			for (unsigned cell_y = 0; cell_y < 12; cell_y++)
 			{
-				// index into character font data
-				unsigned const underline = ((cell_y > 7) && BIT(char_data, 7)) ? 4 : 0;
-				u8 const cell_data = m_j2[(char_data & 0x7f) * 16 + cell_y + underline];
+				u8 cell_data = 0;
+
+				/*
+				 * The J2 (5100) display adapter has 2KiB of character ROS used
+				 * to produce 128 unique characters with normal and underlined
+				 * variants. The G2 (5110) has 4KiB with 256 unique character
+				 * patterns, with only selected characters having underlined
+				 * variations.
+				 */
+				if (m_cgr.bytes() < 4096)
+				{
+					unsigned const underline = ((cell_y > 7) && BIT(char_data, 7)) ? 4 : 0;
+
+					cell_data = m_cgr[(char_data & 0x7f) * 16 + cell_y + underline];
+				}
+				else
+					cell_data = m_cgr[char_data * 16 + cell_y];
 
 				bitmap.pix(y + cell_y * 2, x + 0) = c[BIT(cell_data, 7) ^ reverse];
 				bitmap.pix(y + cell_y * 2, x + 1) = c[BIT(cell_data, 6) ^ reverse];
@@ -265,49 +416,94 @@ void ibm5100_state::da0_ctl_w(u8 data)
 	LOG("da0_ctl_w 0x%02x (%s)\n", data, machine().describe_context());
 
 	// bit 4: 0=display off
+	// bit 3: 0=display on
 	if (!BIT(data, 4))
-		m_f2_ff |= F2_DO;
-	else
-		m_f2_ff &= ~F2_DO;
+		m_bio_ff |= BIO_DO;
+	else if (!BIT(data, 3))
+		m_bio_ff &= ~BIO_DO;
 }
 
-u8 ibm5100_state::e2_sts_r()
+void ibm5110_state::da0_ctl_w(u8 data)
+{
+	ibm5100_state::da0_ctl_w(data);
+
+	// bit 0: 0=alarm on
+	// bit 1: 0=alarm off
+	if (!BIT(data, 0))
+		m_alarm->set_state(1);
+	else if (!BIT(data, 1))
+		m_alarm->set_state(0);
+}
+
+u8 ibm5110_state::exr_sts_r()
+{
+	LOG("exr_sts_r 0x%02x (%s)\n", m_getb_bus, machine().describe_context());
+
+	switch (m_getb_bus)
+	{
+	case 0x80: return m_jmp[0]->read();
+	case 0x40: return m_jmp[1]->read();
+	case 0x20: return m_jmp[2]->read();
+	default:
+		return 0;
+	}
+}
+
+void ibm5110_state::exr_ctl_w(u8 data)
+{
+	LOG("exr_ctl_w 0x%02x (%s)\n", data, machine().describe_context());
+
+	if (BIT(data, 7))
+	{
+		m_exr.select(BIT(m_lang->read(), 6));
+		m_exr_ff |= EXR_ROS2;
+	}
+	else if (BIT(data, 6))
+	{
+		m_exr.disable();
+		m_exr_ff &= ~EXR_ROS2;
+	}
+}
+
+u8 ibm5100_state::nxr_sts_r()
 {
 	u8 data = 0xff;
 
 	if (!machine().side_effects_disabled())
 	{
-		data = (m_e2_ff & E2_PS) ? u8(m_e2_address) : (m_e2_address >> 8);
+		data = (m_nxr_ff & NXR_PS) ? u8(m_nxr_address) : (m_nxr_address >> 8);
 
-		m_e2_ff ^= E2_PS;
+		m_nxr_ff ^= NXR_PS;
 	}
 
 	return data;
 }
 
-void ibm5100_state::e2_ctl_w(u8 data)
+void ibm5100_state::nxr_ctl_w(u8 data)
 {
-	LOG("e2_ctl_w 0x%02x (%s)\n", data, machine().describe_context());
+	LOG("nxr_ctl_w 0x%02x (%s)\n", data, machine().describe_context());
 
-	if (!BIT(data, 3))
-		m_e2_ff &= ~E2_RS;
-	else if (!BIT(data, 2))
-		m_e2_ff |= E2_RS;
+	m_nxr_ff &= ~(NXR_B0 | NXR_PS | NXR_RS);
 
-	m_e2_ff &= ~(E2_B0 | E2_PS);
-	m_e2_address = 0;
+	if (BIT(data, 3))
+		m_nxr_ff |= NXR_BASIC;
+	else if (BIT(data, 2))
+		m_nxr_ff |= NXR_APL;
+
+	m_nxr_address = 0;
 }
 
-u8 ibm5100_state::e2_r()
+u8 ibm5100_state::nxr_r()
 {
 	u8 data = 0xff;
 
 	if (!machine().side_effects_disabled())
 	{
-		bool const basic = m_e2_ff & E2_RS;
+		unsigned const rs = m_nxr_ff & NXR_RS;
+		bool const basic = !(rs & NXR_APL);
 
 		// check model has selected ROS (all models have common)
-		if (BIT(m_conf->read(), 2 + basic) || (basic && m_e2_address >= 0x9000))
+		if (BIT(m_conf->read(), 2 + basic) || (basic && m_nxr_address >= 0x9000))
 		{
 			/*
 			 * APL non-executable ROS is addressed with an unshifted 16-bit
@@ -315,41 +511,79 @@ u8 ibm5100_state::e2_r()
 			 * giving 64KiB. Even and odd bytes are selected by a flip-flop
 			 * which is toggled with each read.
 			 */
-			data = BIT(m_nxr[basic][m_e2_address >> basic], (m_e2_ff & E2_B0) ? 0 : 8, 8);
+			data = BIT(m_nxr[rs][m_nxr_address >> basic], (m_nxr_ff & NXR_B0) ? 0 : 8, 8);
 		}
 
 		// always increment address for BASIC, only on odd bytes for APL
-		if (basic || (m_e2_ff & E2_B0))
-			m_e2_address++;
+		if (basic || (m_nxr_ff & NXR_B0))
+			m_nxr_address++;
 
 		// toggle even/odd byte flip-flop
-		m_e2_ff ^= E2_B0;
+		m_nxr_ff ^= NXR_B0;
 	}
 
 	return data;
 }
 
-void ibm5100_state::e2_w(u8 data)
+u8 ibm5110_state::nxr_r()
 {
-	m_e2_address = (m_e2_address << 8) | data;
+	u8 data = 0xff;
 
-	if (m_e2_ff & E2_PS)
+	if (!machine().side_effects_disabled())
 	{
-		LOG("e2_address 0x%04x (%s)\n", m_e2_address, machine().describe_context());
+		unsigned const rs = m_nxr_ff & NXR_RS;
+
+		// check model has selected ROS (all models have common)
+		if (!(rs & NXR_APL) || BIT(m_conf->read(), 2))
+			data = BIT(m_nxr[rs][m_nxr_address], (m_nxr_ff & NXR_B0) ? 0 : 8, 8);
+
+		// increment after odd bytes
+		if (m_nxr_ff & NXR_B0)
+			m_nxr_address++;
+
+		// toggle even/odd byte flip-flop
+		m_nxr_ff ^= NXR_B0;
+	}
+
+	return data;
+}
+
+void ibm5100_state::nxr_w(u8 data)
+{
+	m_nxr_address = (m_nxr_address << 8) | data;
+
+	if (m_nxr_ff & NXR_PS)
+	{
+		LOG("nxr_address 0x%04x (%s)\n", m_nxr_address, machine().describe_context());
 
 		// data byte even/odd flip-flop is cleared except when BASIC is
 		// selected and the address is odd
-		if ((m_e2_ff & E2_RS) && (m_e2_address & 1))
-			m_e2_ff |= E2_B0;
+		if (!(m_nxr_ff & NXR_APL) && (m_nxr_address & 1))
+			m_nxr_ff |= NXR_B0;
 		else
-			m_e2_ff &= ~E2_B0;
+			m_nxr_ff &= ~NXR_B0;
 	}
 
 	// toggle put strobe flip-flop
-	m_e2_ff ^= E2_PS;
+	m_nxr_ff ^= NXR_PS;
 }
 
-u8 ibm5100_state::f2_kbd_sts_r()
+void ibm5110_state::nxr_w(u8 data)
+{
+	m_nxr_address = (m_nxr_address << 8) | data;
+
+	if (m_nxr_ff & NXR_PS)
+	{
+		LOG("nxr_address 0x%04x (%s)\n", m_nxr_address, machine().describe_context());
+
+		m_nxr_ff &= ~NXR_B0;
+	}
+
+	// toggle put strobe flip-flop
+	m_nxr_ff ^= NXR_PS;
+}
+
+u8 ibm5100_state::kbd_sts_r()
 {
 	if (!machine().side_effects_disabled())
 	{
@@ -357,12 +591,13 @@ u8 ibm5100_state::f2_kbd_sts_r()
 		{
 		case 0x40:
 			// keyboard data gate
+			m_bio_ff &= ~BIO_KI;
 			return m_kbd->read();
 		case 0x80:
 			// keyboard status gate
-			return m_lang->read();
+			return m_lang->read() | (m_bio_ff & BIO_KI);
 		default:
-			LOG("f2_kbd_sts_r: unknown 0x%02x (%s)\n", m_getb_bus, machine().describe_context());
+			LOG("kbd_sts_r: unknown 0x%02x (%s)\n", m_getb_bus, machine().describe_context());
 			break;
 		}
 	}
@@ -370,14 +605,14 @@ u8 ibm5100_state::f2_kbd_sts_r()
 	return 0xff;
 }
 
-void ibm5100_state::f2_kbd_ctl_w(u8 data)
+void ibm5100_state::kbd_ctl_w(u8 data)
 {
-	LOG("f2_kbd_ctl_w 0x%02x (%s)\n", data, machine().describe_context());
+	LOG("kbd_ctl_w 0x%02x (%s)\n", data, machine().describe_context());
 
 	// bit 6: 0=reset and disable keyboard interrupts
 	if (!BIT(data, 6))
 	{
-		m_f2_ff &= ~F2_KIE;
+		m_bio_ff &= ~BIO_KIE;
 
 		m_cpu->set_input_line(palm_device::IRPT_REQ3, 1);
 	}
@@ -391,9 +626,9 @@ void ibm5100_state::f2_kbd_ctl_w(u8 data)
 
 	// bit 0: 0=enable keyboard interrupt
 	if (!BIT(data, 0))
-		m_f2_ff |= F2_KIE;
+		m_bio_ff |= BIO_KIE;
 	else
-		m_f2_ff &= ~F2_KIE;
+		m_bio_ff &= ~BIO_KIE;
 }
 
 void ibm5100_state::daf_ctl_w(u8 data)
@@ -404,8 +639,15 @@ void ibm5100_state::daf_ctl_w(u8 data)
 	//  7   expansion da=8
 	//  6   tape da=e
 	//  5   keyboard da=4
+	if (BIT(data, 5))
+	{
+		m_bio_ff &= ~(BIO_KI | BIO_KIE);
+		m_cpu->set_input_line(palm_device::IRPT_REQ3, 1);
+	}
 	//  4   printer da=5
 	//  3   enable cycle steal
+	if (BIT(data, 3))
+		m_bio_ff &= ~BIO_DO;
 	//  2   reset da=b
 	//  1   reset da=c
 	//  0   reset da=d
@@ -423,6 +665,11 @@ ROM_START(ibm5100)
 	 * BASIC card, however it is selected together with the BASIC ROS and
 	 * logically appended to the address space.
 	 */
+	ROM_REGION16_BE(0x10000, "common", 0)
+	ROM_LOAD("c4.ros", 0x0000, 0x9000, CRC(b1abeb4a) SHA1(e0151fefe63c43c8912599615ddfb7c06f111c72))
+	ROM_LOAD("e2.ros", 0x9000, 0x4800, CRC(be4289c3) SHA1(008ea7bb25fda94540bf5e02eff5a59bb1c86aac))
+	ROM_FILL(0xd800, 0x2800, 0xff)
+
 	ROM_REGION16_BE(0x10000, "basic", 0)
 	ROM_LOAD("c4.ros", 0x0000, 0x9000, CRC(b1abeb4a) SHA1(e0151fefe63c43c8912599615ddfb7c06f111c72))
 	ROM_LOAD("e2.ros", 0x9000, 0x4800, CRC(be4289c3) SHA1(008ea7bb25fda94540bf5e02eff5a59bb1c86aac))
@@ -442,8 +689,47 @@ ROM_START(ibm5100)
 	 * 8x8 cell, then 2x4 byte entries contain the normal and underlined lower
 	 * 4 rows of the total 8x12 cell respectively.
 	 */
-	ROM_REGION(0x800, "j2", 0)
+	ROM_REGION(0x800, "cgr", 0)
 	ROM_LOAD("j2.ros", 0x000, 0x800, CRC(428e5b66) SHA1(9def68eed9dc2b8f08581387f8b74b49b3faf7e7) BAD_DUMP)
+ROM_END
+
+ROM_START(ibm5110)
+	// Executable ROS
+	ROM_REGION16_BE(0x8000, "l2_1", 0)
+	ROM_LOAD("l2_1.ros", 0x0000, 0x8000, CRC(0355894f) SHA1(c76a91cbbec226feb942ccde93ecb1637c88a01b))
+
+	// APL Executable ROS
+	ROM_REGION16_BE(0x8000, "l2_2a", 0)
+	ROM_LOAD("l2_2a.ros", 0x0000, 0x5000, CRC(46918be9) SHA1(bf45a44f77104c55f2ccfa462af06944e6bffe1a))
+	ROM_FILL(0x5000, 0x3000, 0xff)
+
+	// BASIC Executable ROS
+	ROM_REGION16_BE(0x8000, "l2_2b", 0)
+	ROM_LOAD("l2_2b.ros", 0x0000, 0x4000, CRC(a69dd0c1) SHA1(ecdc1363e25b72b695c517af145c50a069b6e8dc))
+	ROM_FILL(0x4000, 0x3000, 0xff)
+
+	// Common and Language non-executable ROS
+	ROM_REGION16_BE(0x20000, "common", 0)
+	ROM_LOAD("f2_c.ros", 0x0000, 0x4000, CRC(83beafb2) SHA1(80ad07a2a83ff395d918b69d5c81a6e94ac7af37))
+	ROM_FILL(0x4000, 0x1c000, 0xff)
+
+	// BASIC non-executable ROS
+	ROM_REGION16_BE(0x20000, "basic", 0)
+	ROM_LOAD("f2_b.ros", 0x0000, 0x12000, CRC(3ffb79b6) SHA1(254f5a7ae739b7bf6a800e8380cf3b6686ee9768))
+	ROM_FILL(0x12000, 0x8000, 0xff)
+
+	// APL non-executable ROS
+	ROM_REGION16_BE(0x20000, "apl", 0)
+	ROM_LOAD("e4.ros", 0x00000, 0x20000, CRC(1e28db20) SHA1(cf12893bb76c44756a9554828d42299b169e560a))
+
+	// Display Adapter ROS
+	/*
+	 * This data was hand-made based on the character map in the documentation.
+	 * It was assumed that the first 12 bytes of each character store the 8x12
+	 * cell, followed by 8x4 empty bytes.
+	 */
+	ROM_REGION(0x1000, "cgr", 0)
+	ROM_LOAD("g2.ros", 0x000, 0x1000, CRC(1f55161c) SHA1(eb22f3177060bd7cb4ba8facaa293147ffeceabc) BAD_DUMP)
 ROM_END
 
 static INPUT_PORTS_START(ibm5100)
@@ -482,7 +768,26 @@ static INPUT_PORTS_START(ibm5100)
 	PORT_CONFSETTING(0x40, "BASIC") PORT_CONDITION("CONF", 0x08, EQUALS, 0x08)
 INPUT_PORTS_END
 
+static INPUT_PORTS_START(ibm5110)
+	PORT_INCLUDE(ibm5100)
+
+	PORT_START("L2_1")
+	PORT_DIPNAME(0xf0, 0xf0, "Model") PORT_DIPLOCATION("L2_1:4,3,2,1")
+	PORT_DIPSETTING(0xf0, "5110-X1X")
+	PORT_DIPSETTING(0xe0, "5110-X2X")
+
+	PORT_START("L2_2")
+	PORT_DIPNAME(0xf0, 0xc0, "L2_2") PORT_DIPLOCATION("L2_2:4,3,2,1")
+	PORT_DIPSETTING(0xc0, DEF_STR(Unknown))
+
+	PORT_START("K4")
+	PORT_DIPNAME(0x80, 0x80, "Feature ROS") PORT_DIPLOCATION("K4:1")
+	PORT_DIPSETTING(0x80, "Absent")
+	PORT_DIPSETTING(0x00, "Present")
+INPUT_PORTS_END
+
 } // anonymous namespace
 
 /*   YEAR  NAME     PARENT  COMPAT  MACHINE  INPUT    CLASS          INIT        COMPANY                            FULLNAME    FLAGS */
 COMP(1975, ibm5100, 0,      0,      ibm5100, ibm5100, ibm5100_state, empty_init, "International Business Machines", "IBM 5100", MACHINE_NO_SOUND_HW)
+COMP(1978, ibm5110, 0,      0,      ibm5110, ibm5110, ibm5110_state, empty_init, "International Business Machines", "IBM 5110", 0)

--- a/src/mame/ibm/ibm5100_kbd.h
+++ b/src/mame/ibm/ibm5100_kbd.h
@@ -22,6 +22,8 @@ public:
 	void lock_w(int state);
 
 protected:
+	ibm5100_keyboard_device(machine_config const &mconfig, device_type type, char const *tag, device_t *owner, u32 clock);
+
 	// device_t implementation
 	virtual ioport_constructor device_input_ports() const override;
 	virtual void device_start() override;
@@ -32,7 +34,7 @@ protected:
 	virtual void key_break(u8 row, u8 column) override;
 	virtual void key_repeat(u8 row, u8 column) override;
 
-	u8 translate(u8 column, u8 row);
+	virtual u8 translate(u8 column, u8 row, u8 modifiers) const;
 
 private:
 	devcb_write_line m_strobe;
@@ -44,6 +46,17 @@ private:
 	bool m_lock;
 };
 
+class ibm5110_keyboard_device
+	: public ibm5100_keyboard_device
+{
+public:
+	ibm5110_keyboard_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock = 0);
+
+protected:
+	virtual u8 translate(u8 column, u8 row, u8 modifiers) const override;
+};
+
 DECLARE_DEVICE_TYPE(IBM5100_KEYBOARD, ibm5100_keyboard_device)
+DECLARE_DEVICE_TYPE(IBM5110_KEYBOARD, ibm5110_keyboard_device)
 
 #endif // MAME_IBM_IBM5100_KBD_H

--- a/src/mame/igs/pgm2.cpp
+++ b/src/mame/igs/pgm2.cpp
@@ -1513,15 +1513,15 @@ void pgm2_state::init_bubucar()
 //Same company but they changed name.
 
 // Oriental Legend 2 - should be a V102 and V100 too
-//西游释厄传2/Xīyóu shì è chuán 2 (China; Simplified Chinese)
+//西游释厄传2/Xīyóu shì è zhuàn 2 (China; Simplified Chinese)
 //西遊釋厄傳2/Saiyū Shakuyakuden 2 (Japan; Traditional Chinese - Taiwan(undumped) too?)
 GAME( 2007, orleg2,       0,      pgm2,        pgm2, pgm2_state, init_orleg2,   ROT0, "IGS", "Oriental Legend 2 (V104, Oversea)", MACHINE_SUPPORTS_SAVE ) // Overseas sets of OL2 do not use the card reader
 GAME( 2007, orleg2_103,   orleg2, pgm2,        pgm2, pgm2_state, init_orleg2,   ROT0, "IGS", "Oriental Legend 2 (V103, Oversea)", MACHINE_SUPPORTS_SAVE )
 GAME( 2007, orleg2_101,   orleg2, pgm2,        pgm2, pgm2_state, init_orleg2,   ROT0, "IGS", "Oriental Legend 2 (V101, Oversea)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 2007, orleg2_104cn, orleg2, pgm2,        pgm2, pgm2_state, init_orleg2,   ROT0, "IGS (Huatong license)", "Xiyou Shi E Chuan 2 (V104, China)", MACHINE_SUPPORTS_SAVE )
-GAME( 2007, orleg2_103cn, orleg2, pgm2,        pgm2, pgm2_state, init_orleg2,   ROT0, "IGS (Huatong license)", "Xiyou Shi E Chuan 2 (V103, China)", MACHINE_SUPPORTS_SAVE )
-GAME( 2007, orleg2_101cn, orleg2, pgm2,        pgm2, pgm2_state, init_orleg2,   ROT0, "IGS (Huatong license)", "Xiyou Shi E Chuan 2 (V101, China)", MACHINE_SUPPORTS_SAVE )
+GAME( 2007, orleg2_104cn, orleg2, pgm2,        pgm2, pgm2_state, init_orleg2,   ROT0, "IGS (Huatong license)", "Xiyou Shi E Zhuan 2 (V104, China)", MACHINE_SUPPORTS_SAVE )
+GAME( 2007, orleg2_103cn, orleg2, pgm2,        pgm2, pgm2_state, init_orleg2,   ROT0, "IGS (Huatong license)", "Xiyou Shi E Zhuan 2 (V103, China)", MACHINE_SUPPORTS_SAVE )
+GAME( 2007, orleg2_101cn, orleg2, pgm2,        pgm2, pgm2_state, init_orleg2,   ROT0, "IGS (Huatong license)", "Xiyou Shi E Zhuan 2 (V101, China)", MACHINE_SUPPORTS_SAVE )
 
 GAME( 2007, orleg2_104jp, orleg2, pgm2,        pgm2, pgm2_state, init_orleg2,   ROT0, "IGS (Alta license)", "Saiyuu Shakuyakuden 2 (V104, Japan)", MACHINE_SUPPORTS_SAVE )
 GAME( 2007, orleg2_103jp, orleg2, pgm2,        pgm2, pgm2_state, init_orleg2,   ROT0, "IGS (Alta license)", "Saiyuu Shakuyakuden 2 (V103, Japan)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/konami/konamim2.cpp
+++ b/src/mame/konami/konamim2.cpp
@@ -1106,7 +1106,7 @@ void konamim2_state::konamim2(machine_config &config)
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_screen_update("bda:vdu", FUNC(m2_vdu_device::screen_update));
 
-	/* Sound hardware */
+	// Sound hardware
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
@@ -1222,7 +1222,7 @@ ROM_START( polystar )
 	ROM_REGION64_BE( 0x200000, "boot", 0 )
 	ROM_LOAD16_WORD( "623b01.8q", 0x000000, 0x200000, CRC(bd879f93) SHA1(e2d63bfbd2b15260a2664082652442eadea3eab6) )
 
-	ROM_REGION16_BE( 0x80, "eeprom", 0 ) /* EEPROM default contents */
+	ROM_REGION16_BE( 0x80, "eeprom", 0 ) // EEPROM default contents
 	ROM_LOAD( "93c46.7k", 0x000000, 0x000080, CRC(fab5a203) SHA1(153e22aa8cfce80b77ba200957685f796fc99b1c) )
 
 	DISK_REGION( "ata:0:cr589" ) // Has 1s of silence near the start of the first audio track
@@ -1236,7 +1236,7 @@ ROM_START( btltryst )
 	ROM_REGION16_BE( 0x80, "eeprom", 0 )
 	ROM_LOAD( "93c46.7k",  0x000000, 0x000080, CRC(cc2c5640) SHA1(694cf2b3700f52ed80252b013052c90020e58ce6) )
 
-	ROM_REGION( 0x2000, "m48t58", 0 ) /* timekeeper SRAM */
+	ROM_REGION( 0x2000, "m48t58", 0 ) // timekeeper SRAM
 	ROM_LOAD( "m48t58", 0x000000, 0x002000, CRC(71ee073b) SHA1(cc8002d7ee8d1695aebbbb2a3a1e97a7e16948c1) )
 
 	DISK_REGION( "ata:0:cr589" )
@@ -1248,7 +1248,7 @@ ROM_START( btltrysta )
 	ROM_REGION64_BE( 0x200000, "boot", 0 )
 	ROM_LOAD16_WORD( "636a01.8q", 0x000000, 0x200000, CRC(7b1dc738) SHA1(32ae8e7ddd38fcc70b4410275a2cc5e9a0d7d33b) )
 
-	ROM_REGION( 0x2000, "m48t58", 0 ) /* timekeeper SRAM */
+	ROM_REGION( 0x2000, "m48t58", 0 ) // timekeeper SRAM
 	ROM_LOAD( "m48t58y", 0x000000, 0x002000, CRC(8611ff09) SHA1(6410236947d99c552c4a1f7dd5fd8c7a5ae4cba1) )
 
 	DISK_REGION( "ata:0:cr589" )
@@ -1257,30 +1257,33 @@ ROM_END
 #endif
 
 ROM_START( heatof11 )
-	ROM_REGION64_BE( 0x200000, "boot", 0 )  /* boot rom */
+	ROM_REGION64_BE( 0x200000, "boot", 0 )  // boot ROM
 	ROM_LOAD16_WORD( "636a01.8q", 0x000000, 0x200000, CRC(7b1dc738) SHA1(32ae8e7ddd38fcc70b4410275a2cc5e9a0d7d33b) )
 
-	ROM_REGION16_BE( 0x80, "eeprom", 0 ) /* EEPROM default contents */
+	ROM_REGION16_BE( 0x80, "eeprom", 0 ) // EEPROM default contents
 	ROM_LOAD( "93c46.7k",  0x000000, 0x000080, CRC(e7029938) SHA1(ae41340dbcb600debe246629dc36fb371d1a5b05) )
 
-	ROM_REGION( 0x2000, "m48t58", 0 ) /* timekeeper SRAM */
+	ROM_REGION( 0x2000, "m48t58", 0 ) // timekeeper SRAM
 	ROM_LOAD( "dallas.5e",  0x000000, 0x002000, CRC(5b74eafd) SHA1(afbf5f1f5a27407fd6f17c764bbb7fae4ab779f5) )
 
 	DISK_REGION( "ata:0:cr589" )
-	DISK_IMAGE_READONLY( "heatof11", 0, BAD_DUMP SHA1(5a0a2782cd8676d3f6dfad4e0f805b309e230d8b) )
+	/* Ring codes found on the disc:
+          703EAA02 PN.0000046809  1 + + + + +  IFPI L251
+          IFPI 42MO */
+	DISK_IMAGE_READONLY( "703eaa02", 0, SHA1(f8a87eacfdbbd22659f39c7a72e3895f0a7697b7) )
 ROM_END
 
 ROM_START( evilngt )
 	ROM_REGION64_BE( 0x200000, "boot", 0 )
 	ROM_LOAD16_WORD( "636a01.8q", 0x000000, 0x200000, CRC(7b1dc738) SHA1(32ae8e7ddd38fcc70b4410275a2cc5e9a0d7d33b) )
 
-	ROM_REGION16_BE( 0x80, "eeprom", 0 ) /* EEPROM default contents */
+	ROM_REGION16_BE( 0x80, "eeprom", 0 ) // EEPROM default contents
 	ROM_LOAD( "93c46.7k", 0x000000, 0x000080, CRC(60ae825e) SHA1(fd61db9667c53dd12700a0fe202fcd1e3d35d206) )
 
-	ROM_REGION( 0x2000, "m48t58", 0 ) /* timekeeper SRAM */
+	ROM_REGION( 0x2000, "m48t58", 0 ) // timekeeper SRAM
 	ROM_LOAD( "m48t58y.9n", 0x000000, 0x002000, CRC(e887ca1f) SHA1(54205f01b1ceba1d5f4d979fc30be1add8116e90) )
 
-	ROM_REGION( 0x400000, "ymz", 0 ) /* YMZ280B sound rom on sub board */
+	ROM_REGION( 0x400000, "ymz", 0 ) // YMZ280B sound ROM on sub board
 	ROM_LOAD( "810a03.16h", 0x000000, 0x400000, CRC(05112d3a) SHA1(0df2a167b7bc08a32d983b71614d59834efbfb59) )
 
 	DISK_REGION( "ata:0:cr589" )
@@ -1291,13 +1294,13 @@ ROM_START( hellngt )
 	ROM_REGION64_BE( 0x200000, "boot", 0 )
 	ROM_LOAD16_WORD( "636a01.8q", 0x000000, 0x200000, CRC(7b1dc738) SHA1(32ae8e7ddd38fcc70b4410275a2cc5e9a0d7d33b) )
 
-	ROM_REGION16_BE( 0x80, "eeprom", 0 ) /* EEPROM default contents */
+	ROM_REGION16_BE( 0x80, "eeprom", 0 ) // EEPROM default contents
 	ROM_LOAD( "93c46.7k",    0x000000, 0x000080, CRC(53b41f68) SHA1(f75f59808a5b04b1e49f2cca0592a2466b82f019) )
 
 	ROM_REGION( 0x2000, "m48t58", 0 )
 	ROM_LOAD( "m48t58y.9n",  0x000000, 0x002000, CRC(ff8e78a1) SHA1(02e56f55264dd0bf3a08808726a6366e9cb6031e) )
 
-	ROM_REGION( 0x400000, "ymz", 0 ) /* YMZ280B sound rom on sub board */
+	ROM_REGION( 0x400000, "ymz", 0 ) // YMZ280B sound ROM on sub board
 	ROM_LOAD( "810a03.16h",  0x000000, 0x400000, CRC(05112d3a) SHA1(0df2a167b7bc08a32d983b71614d59834efbfb59) )
 
 	DISK_REGION( "ata:0:cr589" )
@@ -1311,7 +1314,7 @@ ROM_START( totlvice )
 	ROM_REGION16_BE( 0x80, "eeprom", 0 )
 	ROM_LOAD( "93c46.7k", 0x000000, 0x000080, CRC(25aa0bd1) SHA1(cc461e0629ff71c3a868882f1f67af0e19135c1a) )
 
-	ROM_REGION( 0x100000, "ymz", 0 ) /* YMZ280B sound rom on sub board */
+	ROM_REGION( 0x100000, "ymz", 0 ) // YMZ280B sound rom on sub board
 	ROM_LOAD( "639jaa02.bin",  0x000000, 0x100000, CRC(c6163818) SHA1(b6f8f2d808b98610becc0a5be5443ece3908df0b) )
 
 	DISK_REGION( "ata:0:cr589" )
@@ -1324,7 +1327,7 @@ ROM_START( totlvicd )
 	ROM_REGION64_BE( 0x200000, "boot", 0 )
 	ROM_LOAD16_WORD( "623b01.8q", 0x000000, 0x200000, CRC(bd879f93) SHA1(e2d63bfbd2b15260a2664082652442eadea3eab6) )
 
-	ROM_REGION( 0x100000, "ymz", 0 ) /* YMZ280B sound rom on sub board */
+	ROM_REGION( 0x100000, "ymz", 0 ) // YMZ280B sound rom on sub board
 	ROM_LOAD( "639jaa02.bin",  0x000000, 0x100000, CRC(c6163818) SHA1(b6f8f2d808b98610becc0a5be5443ece3908df0b) )
 
 	DISK_REGION( "ata:0:cr589" )
@@ -1336,7 +1339,7 @@ ROM_START( totlvicu )
 	ROM_REGION64_BE( 0x200000, "boot", 0 )
 	ROM_LOAD16_WORD( "623b01.8q", 0x000000, 0x200000, CRC(bd879f93) SHA1(e2d63bfbd2b15260a2664082652442eadea3eab6) )
 
-	ROM_REGION( 0x100000, "ymz", 0 ) /* YMZ280B sound rom on sub board */
+	ROM_REGION( 0x100000, "ymz", 0 ) // YMZ280B sound rom on sub board
 	ROM_LOAD( "639jaa02.bin",  0x000000, 0x100000, CRC(c6163818) SHA1(b6f8f2d808b98610becc0a5be5443ece3908df0b) )
 
 	DISK_REGION( "ata:0:cr589" )
@@ -1347,7 +1350,7 @@ ROM_START( totlvica )
 	ROM_REGION64_BE( 0x200000, "boot", 0 )
 	ROM_LOAD16_WORD( "623b01.8q", 0x000000, 0x200000, CRC(bd879f93) SHA1(e2d63bfbd2b15260a2664082652442eadea3eab6) )
 
-	ROM_REGION( 0x100000, "ymz", 0 ) /* YMZ280B sound rom on sub board */
+	ROM_REGION( 0x100000, "ymz", 0 ) // YMZ280B sound rom on sub board
 	ROM_LOAD( "639jaa02.bin",  0x000000, 0x100000, CRC(c6163818) SHA1(b6f8f2d808b98610becc0a5be5443ece3908df0b) )
 
 	DISK_REGION( "ata:0:cr589" )
@@ -1358,7 +1361,7 @@ ROM_START( totlvicj )
 	ROM_REGION64_BE( 0x200000, "boot", 0 )
 	ROM_LOAD16_WORD( "623b01.8q", 0x000000, 0x200000, CRC(bd879f93) SHA1(e2d63bfbd2b15260a2664082652442eadea3eab6) )
 
-	ROM_REGION( 0x100000, "ymz", 0 ) /* YMZ280B sound rom on sub board */
+	ROM_REGION( 0x100000, "ymz", 0 ) // YMZ280B sound rom on sub board
 	ROM_LOAD( "639jaa02.bin",  0x000000, 0x100000, CRC(c6163818) SHA1(b6f8f2d808b98610becc0a5be5443ece3908df0b) )
 
 	DISK_REGION( "ata:0:cr589" ) // Need a re-image
@@ -1455,21 +1458,21 @@ void konamim2_state::dump_task_command(const std::vector<std::string_view> &para
 
 	struct ItemNode
 	{
-		m2ptr pn_Next;    /* pointer to next in list              */ // 0
-		m2ptr pn_Prev;    /* pointer to previous in list          */ // 4
+		m2ptr pn_Next;                /* pointer to next in list              */ // 0
+		m2ptr pn_Prev;                /* pointer to previous in list          */ // 4
 		uint8_t     n_SubsysType;     /* what component manages this node     */ // 8
 		uint8_t     n_Type;           /* what type of node for the component  */ // 9
 		uint8_t     n_Priority;       /* queueing priority                    */ // A
 		uint8_t     n_Flags;          /* misc flags, see below                */ // B
 		int32_t     n_Size;           /* total size of node including hdr     */ // C
-		m2ptr    pn_Name;           /* name of item, or NULL                */ // 10
+		m2ptr    pn_Name;             /* name of item, or NULL                */ // 10
 		uint8_t     n_Version;        /* version of of this Item              */ // 14
 		uint8_t     n_Revision;       /* revision of this Item                */ // 15
 		uint8_t     n_Reserved0;      /* reserved for future use              */ // 16
 		uint8_t     n_ItemFlags;      /* additional system item flags         */ // 17
-		Item      n_Item;           /* Item number representing this struct */ //18
-		Item      n_Owner;          /* creator, present owner, disposer     */ // 1C
-		m2ptr     pn_Reserved1;      /* reserved for future use              */ // 20
+		Item      n_Item;             /* Item number representing this struct */ //18
+		Item      n_Owner;            /* creator, present owner, disposer     */ // 1C
+		m2ptr     pn_Reserved1;       /* reserved for future use              */ // 20
 	};
 
 	struct Task
@@ -1479,7 +1482,7 @@ void konamim2_state::dump_task_command(const std::vector<std::string_view> &para
 		uint32_t     t_WaitBits;        /* signals being waited for     */
 		uint32_t     t_SigBits;         /* signals received             */
 		uint32_t     t_AllocatedSigs;   /* signals allocated            */
-		m2ptr        pt_StackBase;       /* base of stack                */
+		m2ptr        pt_StackBase;      /* base of stack                */
 		int32_t      t_StackSize;       /* size of stack                */
 		uint32_t     t_MaxUSecs;        /* quantum length in usecs      */
 		TimerTicks   t_ElapsedTime;     /* time spent running this task */
@@ -1487,7 +1490,7 @@ void konamim2_state::dump_task_command(const std::vector<std::string_view> &para
 		uint32_t     t_Flags;           /* task flags                   */
 		Item         t_Module;          /* the module we live within    */
 		Item         t_DefaultMsgPort;  /* default task msgport         */
-		m2ptr         pt_UserData;        /* user-private data            */
+		m2ptr         pt_UserData;      /* user-private data            */
 	};
 
 	debugger_console &con = machine().debugger().console();
@@ -1556,7 +1559,7 @@ void konamim2_state::dump_task_command(const std::vector<std::string_view> &para
 //  uint32_t     t_WaitBits;        /* signals being waited for     */
 //  uint32_t     t_SigBits;         /* signals received             */
 //  uint32_t     t_AllocatedSigs;   /* signals allocated            */
-//  m2ptr        pt_StackBase;       /* base of stack                */
+//  m2ptr        pt_StackBase;      /* base of stack                */
 //  int32_t      t_StackSize;       /* size of stack                */
 //  uint32_t     t_MaxUSecs;        /* quantum length in usecs      */
 //  TimerTicks   t_ElapsedTime;     /* time spent running this task */
@@ -1564,7 +1567,7 @@ void konamim2_state::dump_task_command(const std::vector<std::string_view> &para
 //  uint32_t     t_Flags;           /* task flags                   */
 //  Item         t_Module;          /* the module we live within    */
 //  Item         t_DefaultMsgPort;  /* default task msgport         */
-//  m2ptr         pt_UserData;        /* user-private data            */
+//  m2ptr         pt_UserData;      /* user-private data            */
 
 	con.printf("**** Task Info @ %08X ****\n", address);
 	con.printf("Next:        %08X\n", task.t.pn_Next);

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -15897,6 +15897,7 @@ pangbp                          // bootleg
 pkladies                        // (c) 1989 Mitchell
 pkladiesbl                      // bootleg
 pkladiesbl2                     // bootleg
+pkladiesblu                     // bootleg
 pkladiesl                       // (c) 1989 Leprechaun
 pkladiesla                      // (c) 1989 Leprechaun
 pompingw                        // (c) 1989 Mitchell (Japan)
@@ -19804,6 +19805,7 @@ ibm3153                         //
 
 @source:ibm/ibm5100.cpp
 ibm5100
+ibm5110
 
 @source:ibm/ibm5550.cpp
 ibm5550                         //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -27384,6 +27384,7 @@ rotaryf                         //
 demndrgn                        // (c) 1982 Bally Midway
 ebases                          // (c) 1980
 gorf                            // (c) 1981
+gorfirec                        // (c) 1981
 gorfpgm1                        // (c) 1981
 gorfpgm1f                       // (c) 1981
 gorfpgm1g                       // (c) 1981

--- a/src/mame/midway/astrocde.cpp
+++ b/src/mame/midway/astrocde.cpp
@@ -965,6 +965,15 @@ static INPUT_PORTS_START( gorfpgm1g )
 	PORT_DIPSETTING(    0x00, "Foreign (German ROM)" )
 INPUT_PORTS_END
 
+static INPUT_PORTS_START( gorfirec )
+	PORT_INCLUDE(gorf)
+
+	PORT_MODIFY("P4HANDLE")
+	PORT_DIPNAME( 0x08, 0x08, DEF_STR( Language ) )     PORT_DIPLOCATION("S1:4")
+	PORT_DIPSETTING(    0x08, DEF_STR( Spanish ) )
+	PORT_DIPSETTING(    0x00, "Foreign (NEED ROM)" )    // "Requires A082-91374-A000"
+INPUT_PORTS_END
+
 
 static INPUT_PORTS_START( robby )
 	PORT_START("P1HANDLE")
@@ -1647,6 +1656,20 @@ ROM_START( gorfpgm1g )
 	ROM_LOAD( "german.x11",   0xc000, 0x1000, CRC(3a3dbdcb) SHA1(e20895d41d66d1a23cc445e4ae4628b16ebf83f2) )
 ROM_END
 
+/* PCB engraved as "MIDWAY MFC  A IRECSA".
+   ROM test fails in test mode, it seems Irecsa didn't bother to change the checksums. */
+ROM_START( gorfirec )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "a.bin", 0x0000, 0x1000, CRC(97cb4a6a) SHA1(efdae9a437c665fb861665a38c6cb13fd848ad91) )
+	ROM_LOAD( "b.bin", 0x1000, 0x1000, CRC(e35701c0) SHA1(30794aa97e1ec1c949f74e20a830224e1b5ae8b8) )
+	ROM_LOAD( "c.bin", 0x2000, 0x1000, CRC(16b0638b) SHA1(65e1e2e4df80140976915e0982ce3219b14beece) )
+	ROM_LOAD( "d.bin", 0x3000, 0x1000, CRC(0dccdfc4) SHA1(f55217e98169df41b8906f880ac78a2d0d56f68a) )
+	ROM_LOAD( "e.bin", 0x8000, 0x1000, CRC(8e82804b) SHA1(24250edb30efa63c80514629c86c9372b7ca3020) )
+	ROM_LOAD( "f.bin", 0x9000, 0x1000, CRC(715fb4d9) SHA1(c9f33162093e6ed7e3cb6bb716419e5bc43c0381) )
+	ROM_LOAD( "g.bin", 0xa000, 0x1000, CRC(fb5b7131) SHA1(865ec4f912418f08ff08910ddd61ac7ebd7b30d5) )
+	ROM_LOAD( "h.bin", 0xb000, 0x1000, CRC(578ade88) SHA1(78a27e08aeef7acb648ab9db62a3e87720792aff) )
+ROM_END
+
 
 ROM_START( robby )
 	ROM_REGION( 0x10000, "maincpu", 0 )
@@ -1844,31 +1867,33 @@ void astrocde_state::init_tenpindx()
  *
  *************************************/
 
-/* 90002 CPU board + 90700 game board + 91312 "characterization card" */
+// 90002 CPU board + 90700 game board + 91312 "characterization card"
 GAMEL( 1978, seawolf2,  0,    seawolf2, seawolf2,  seawolf2_state, init_seawolf2, ROT0,   "Dave Nutting Associates / Midway", "Sea Wolf II", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE, layout_seawolf2 )
 
-/* 91354 CPU board + 90700 game board + 91356 RAM board */
+// 91354 CPU board + 90700 game board + 91356 RAM board
 GAMEL( 1980, ebases,    0,    ebases,   ebases,    ebases_state,   init_ebases,   ROT0,   "Dave Nutting Associates / Midway", "Extra Bases", MACHINE_SUPPORTS_SAVE, layout_spacezap )
 
-/* 91354 CPU board + 90706 game board + 91356 RAM board + 91355 pattern board */
+// 91354 CPU board + 90706 game board + 91356 RAM board + 91355 pattern board
 GAMEL( 1980, spacezap,  0,    spacezap, spacezap,  astrocde_state, init_spacezap, ROT0,   "Midway", "Space Zap (Midway)", MACHINE_SUPPORTS_SAVE, layout_spacezap ) // there's also an older version by Game-A-Tron on different hardware
 
-/* 91354 CPU board + 90708 game board + 91356 RAM board + 91355 pattern board + 91397 memory board */
-GAME(  1980, wow,       0,    wow,      wow,       astrocde_state, init_wow,      ROT0,   "Dave Nutting Associates / Midway", "Wizard of Wor", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME(  1980, wowg,      wow,  wow,      wowg,      astrocde_state, init_wow,      ROT0,   "Dave Nutting Associates / Midway", "Wizard of Wor (with German Language ROM)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+// 91354 CPU board + 90708 game board + 91356 RAM board + 91355 pattern board + 91397 memory board
+GAME(  1980, wow,       0,    wow,      wow,       astrocde_state, init_wow,      ROT0,   "Dave Nutting Associates / Midway", "Wizard of Wor",                            MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME(  1980, wowg,      wow,  wow,      wowg,      astrocde_state, init_wow,      ROT0,   "Dave Nutting Associates / Midway", "Wizard of Wor (with German language ROM)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
 
-/* 91354 CPU board + 90708 game board + 91356 RAM board + 91355 pattern board + 91364 ROM/RAM board */
-GAMEL( 1981, gorf,      0,    gorf,     gorf,      astrocde_state, init_gorf,     ROT270, "Dave Nutting Associates / Midway", "Gorf", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE, layout_gorf  )
-GAMEL( 1981, gorfpgm1,  gorf, gorf,     gorf,      astrocde_state, init_gorf,     ROT270, "Dave Nutting Associates / Midway", "Gorf (program 1)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE, layout_gorf )
-GAMEL( 1981, gorfpgm1f, gorf, gorf,     gorfpgm1f, astrocde_state, init_gorf,     ROT270, "Dave Nutting Associates / Midway", "Gorf (program 1, with French Language ROM)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE, layout_gorf )
-GAMEL( 1981, gorfpgm1g, gorf, gorf,     gorfpgm1g, astrocde_state, init_gorf,     ROT270, "Dave Nutting Associates / Midway", "Gorf (program 1, with German Language ROM)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE, layout_gorf )
+// 91354 CPU board + 90708 game board + 91356 RAM board + 91355 pattern board + 91364 ROM/RAM board
+GAMEL( 1981, gorf,      0,    gorf,     gorf,      astrocde_state, init_gorf,     ROT270, "Dave Nutting Associates / Midway",                  "Gorf",                                       MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE, layout_gorf )
+GAMEL( 1981, gorfpgm1,  gorf, gorf,     gorf,      astrocde_state, init_gorf,     ROT270, "Dave Nutting Associates / Midway",                  "Gorf (program 1)",                           MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE, layout_gorf )
+GAMEL( 1981, gorfpgm1f, gorf, gorf,     gorfpgm1f, astrocde_state, init_gorf,     ROT270, "Dave Nutting Associates / Midway",                  "Gorf (program 1, with French language ROM)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE, layout_gorf )
+GAMEL( 1981, gorfpgm1g, gorf, gorf,     gorfpgm1g, astrocde_state, init_gorf,     ROT270, "Dave Nutting Associates / Midway",                  "Gorf (program 1, with German language ROM)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE, layout_gorf )
+GAMEL( 1981, gorfirec,  gorf, gorf,     gorfirec,  astrocde_state, init_gorf,     ROT270, "Dave Nutting Associates / Midway (Irecsa license)", "Gorf (Spain, Irecsa license)",               MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE, layout_gorf )
 
-/* 91354 CPU board + 90708 game board + 91356 RAM board + 91355 pattern board + 91423 memory board */
+
+// 91354 CPU board + 90708 game board + 91356 RAM board + 91355 pattern board + 91423 memory board
 GAME(  1981, robby,     0,    robby,    robby,     astrocde_state, init_robby,    ROT0,   "Dave Nutting Associates / Bally Midway", "The Adventures of Robby Roto!", MACHINE_SUPPORTS_SAVE )
 
-/* 91465 CPU board + 91469 game board + 91466 RAM board + 91488 pattern board + 91467 memory board + 91846 EPROM board */
+// 91465 CPU board + 91469 game board + 91466 RAM board + 91488 pattern board + 91467 memory board + 91846 EPROM board
 GAME(  1983, profpac,   0,    profpac,  profpac,   astrocde_state, init_profpac,  ROT0,   "Dave Nutting Associates / Bally Midway", "Professor Pac-Man", MACHINE_SUPPORTS_SAVE )
 
-/* 91465 CPU board + 91699 game board + 91466 RAM board + 91488 pattern board + 91467 memory board */
+// 91465 CPU board + 91699 game board + 91466 RAM board + 91488 pattern board + 91467 memory board
 GAME(  1982, demndrgn,  0,    demndrgn, demndrgn,  demndrgn_state, init_demndrgn, ROT0,   "Dave Nutting Associates / Bally Midway", "Demons & Dragons (prototype)", MACHINE_IS_INCOMPLETE | MACHINE_NO_SOUND | MACHINE_SUPPORTS_SAVE )
-GAMEL( 1983, tenpindx,  0,    tenpindx, tenpindx,  tenpindx_state, init_tenpindx, ROT0,   "Dave Nutting Associates / Bally Midway", "Ten Pin Deluxe", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE | MACHINE_MECHANICAL, layout_tenpindx )
+GAMEL( 1983, tenpindx,  0,    tenpindx, tenpindx,  tenpindx_state, init_tenpindx, ROT0,   "Dave Nutting Associates / Bally Midway", "Ten Pin Deluxe",               MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE | MACHINE_MECHANICAL, layout_tenpindx )

--- a/src/mame/namco/namcops2.cpp
+++ b/src/mame/namco/namcops2.cpp
@@ -36,18 +36,21 @@ Capcom Fighting Jam/Capcom Fighting Evolution... XXXX56X  JAM1 DVD0            D
 Cobra The Arcade................................ XXXX56X  CBR1-HA              HDD (40GB)   NM00021   CBR1 Ver.B             Namco 2004                    Requires RAYS I/O PCB and IR guns and IR sensors. HDD: Maxtor DiamondMax Plus 8 40GB 6E040L0
 Dragon Chronicles (satellite)................... ------X *DCO31-TS CD0        *CD           NM00020   DC001 Ver.A            Namco 2002                    \
 Dragon Chronicles Legend of the Master Ark (sat) ------X *DGC11 CD0           *CD          *NM00014  *DGC11 Ver.A1           Namco 200?                    | server is a custom PC
-Druaga Online The Story Of Aon (satellite)...... XXXX56X  DOL160-1-ST-DVD0-H   DVD          NM00028   DOL165-1-ST-I Ver1.65  Namco 2004                    |
+Druaga Online The Story Of Aon (satellite)...... XXXX56X  DOL160-1-ST-DVD0-H   DVD          NM00028   DOL165-1-ST-I Ver1.65  Namco 2004                    | Uses the V290 or V300 I/O Boards.
    "                                      ...... XXXX56X  DOL150-1-ST-DVD0-G   DVD          NM00028  *?                      Namco 2004                    |
    "                                      ...... XXXX56X  DOL140-1-ST-DVD0-F   DVD          NM00028  *?                      Namco 2004                    |
    "                                      ...... XXXX56X  DOL120-1-ST-DVD0-D   DVD          NM00028  *?                      Namco 2004                    |
    "                                      ...... XXXX56X  DOL110-1-ST-DVD0-C   DVD          NM00028  *?                      Namco 2004                    /
 Fate / Unlimited Codes.......................... X23456X  FUD-HDD0-A           HDD (80GB)   NM00048   FUD1 Ver.A             Capcom/Type-Moon/Cavia/8ing 2008 HDD: Western Digital WD800BB
 Gundam vs Gundam Next........................... XXXX56X  GNX100-1-NA-HDD0-A   HDD (80GB)   NM00052   GNX1001-NA-A           Bandai/Capcom 2009            HDD: Western Digital WD800BB
-Idol Master..................................... ------X *IDM1-HA             *HDD         *NM00022  *IDMS1 Ver.A            Namco 2004
+THE IDOLM@STER (Station)........................ XXX45-X  IDM1-HA              HDD (40GB)   NM00022   IDMS1 Ver.D            Namco 2004                    Uses the V290 or V300 I/O Boards.
+THE IDOLM@STER (Tower).......................... XXX45-X  IDM1-HA              HDD (40GB)   NM00022   IDMT1 Ver.D            Namco 2004                    Uses the V290 or V300 I/O Boards. Can be a Local server for Station units.
 Kinnikuman Muscle Grand Prix.................... XXXX56X  KN1-B                DVD          NM00029   KN1 Ver.A              Banpresto 2006                #
 Kinnikuman Muscle Grand Prix 2.................. XXXX56X  KN2                  DVD          NM00040   KN2 Ver.A              Banpresto 2007                #
-Minna de Kitaeru Zenno Training................. ------X *ZNT100-1-NA-DVD0    *DVD          NM00036   ZNT100-1-ST-A          Namco 2006
-Minna de Kitaeru Zenno Training.(Ver. 1.50)..... ------X  ZNT100-1-NA-DVD0-B   DVD          NM00036   ZNT100-1-ST-A          Namco 2007
+Minna de Kitaeru Zenno Training................. ----56X  ZNT100-1-NA-DVD0-A   DVD          NM00036   ZNT100-1-ST-A          Namco 2006
+Minna de Kitaeru Zenno Training.(Ver. 1.50)..... ----56X  ZNT150-1-NA-DVD0-A   DVD          NM00036   ZNT100-1-ST-A          Namco 2007
+Minna de Kitaeru Zenno Training.(Ver. 1.50)..... ----56X  ZNT150-1-NA-DVD0-B   DVD          NM00036   ZNT100-1-ST-A          Namco 2007
+Minna de Kitaeru Zenno Training.(Ver. 1.60)..... ----56X  ZNT150-1-NA-DVD0-A   DVD          NM00036   ZNT100-1-ST-A          Namco 2007
 Mobile Suit Gundam - Gundam vs Gundam........... XXXX56X  GVS1 DVD0B           DVD          NM00043   GVS1 Ver.A             Bandai/Capcom 2008
 Mobile Suit Gundam SEED O.M.N.I. vs Z.A.F.T..... 123456X  SED1 DVD0            DVD          NM00024   SED1 Ver.A             Banpresto 2005                % #
 M.S. Gundam SEED Destiny O.M.N.I. vs Z.A.F.T. II 123456X  GSD1 DVD0            DVD          NM00034   GSD1 Ver.A             Banpresto 2006                % #
@@ -615,11 +618,17 @@ Notes:
 
 V290 FCB PCB is almost identical to FCA PCB. The main differences are changed internal MCU code & PIC code,
 some extra/different connectors, less D1017 driver transistors and an added RS-232 IC.
-The V290 FCB PCB is used with touchscreen games such as Dragon Chronicles, Druaga Online, Idol Master etc.
+The V290 FCB PCB is used with touchscreen games such as Dragon Chronicles, Druaga Online, THE IDOLM@STER etc.
 It supports a serial touchscreen interface, card readers and buttons.
 The additional devices are supported via J108 which connects to another PCB 'XOU020-A' which contains a
 Texas Instruments TMS32VC540x DSP, TSOP32 flash ROM and other components.
 
+V300 FCB PCB
+2606960100 (2582960101)
+
+Notes: V300 FCB PCB is almost identical to the V290 FCB PCB. The main differences are changed internal MCU
+code & PIC code, more output transistors and an traded the RS-232 for a RS-232C IC.
+[to-do]
 
 System246 JAMMA(B) PCB
 8908962701 (8908972701)


### PR DESCRIPTION
1:  Added back original comment for "PORT_BIT(0x4000" in stretdriv / Hard Drivin's Airborne. 

Tested this more and it is in fact a integral part of how the wheel operates just not how I expected, if you remove it the wheel won't work in game so it's got to be doing something even if it appears when you manually activate it that it's only being applied or used in the test menu. Was investigating it in a effort to try and fix or mitigate the steering wheel centring bug in Hard Drivin's Airborne but i think it's a game code issue and not a emulator issue and i've tried different ways to get around it using the emulator source code related to the functioning of this game and can't find a work around.

2: Tidied up some input description comments for Hard Drivin's Airborne and removed PORT_TOGGLE for Reverse button.