### PR TITLE
New values for wheel edge detection & more popmessage debug info.

### DIFF
--- a/src/mame/atari/harddriv_m.cpp
+++ b/src/mame/atari/harddriv_m.cpp
@@ -271,12 +271,12 @@ uint16_t harddriv_state::hdc68k_wheel_r()
 	/* grab the new wheel value */
 	uint16_t new_wheel = m_12badc[0].read_safe(0xffff);
 
-	/* hack to display the wheel position */
+	/* hack to display the wheel position, last wheel position and wheel edge for debugging. */
 	if (machine().input().code_pressed(KEYCODE_LSHIFT))
-		popmessage("%04X", new_wheel);
+		popmessage("New: %04X Last: %04X Debug: P Edge: %d", new_wheel, m_hdc68k_last_wheel, m_hdc68k_wheel_edge);
 
 	/* if we crossed the center line, latch the edge bit */
-	if ((m_hdc68k_last_wheel / 0xf00) != (new_wheel / 0xf00))
+	if ((m_hdc68k_last_wheel / 0x200) != (new_wheel / 0x200)) 
 		m_hdc68k_wheel_edge = 1;
 
 	/* remember the last value and return the low 8 bits */


### PR DESCRIPTION
harddriv_m.cpp

@cuavas Updated the values for wheel_edge latch bit to reflect the new POPRT_MINMAX in harddriv.cpp so that it now sets m_hdc68k_wheel_edge = 1 when crossing the center point of the wheel. Still doesn't fix the center point bug in Hard Drivin's Airborne but it's a start? 

Added more info the the popmessage for debugging to make it clear when the m_hdc68k_wheel_edge value changes from 1 to 0. When it is set to 0 by the game code it seems to be when the center point of the wheel gets changed to something it shouldn't be and causes the steering wheel centring bug under certain conditions like then the car crashes and is respawning you back on the track and the 2nd last checkpoint on the Mountain track. If you let go of the wheel when you crash before the m_hdc68k_wheel_edge = 0 it stops the bugs from happening but i don't know what is causing it to happen on the 2nd last checkpoint on the mountain track. The only way to get around it seems to be not touching the wheel whilst going through that checkpoint but i think it still goes slightly off center at that specific point in the game and then escalates from there until you either crash the car to reset it or you run out of time and restart the game.